### PR TITLE
Export missing schema in build.properties

### DIFF
--- a/plugins/org.obeonetwork.m2doc.ui/build.properties
+++ b/plugins/org.obeonetwork.m2doc.ui/build.properties
@@ -15,5 +15,6 @@ output.. = bin/
 bin.includes = plugin.xml,\
                META-INF/,\
                .,\
-               plugin.properties
+               plugin.properties,\
+               schema/
 jre.compilation.profile = JavaSE-1.6


### PR DESCRIPTION
The extension point org.obeonetwork.m2doc.services.register should be usable now

Signed-off-by: Mathieu Cartaud <mathieu.cartaud@obeo.fr>