### PR TITLE
Representation create

### DIFF
--- a/plugins/org.obeonetwork.m2doc.sirius/plugin.xml
+++ b/plugins/org.obeonetwork.m2doc.sirius/plugin.xml
@@ -32,6 +32,9 @@
       <configuration
             providerClass="org.obeonetwork.m2doc.sirius.providers.configuration.SiriusConfigurationProvider">
       </configuration>
+      <configuration
+            providerClass="org.obeonetwork.m2doc.sirius.session.SessionCleaner">
+      </configuration>
    </extension>
 
 </plugin>

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/commands/ExportRepresentationCommand.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/commands/ExportRepresentationCommand.java
@@ -103,12 +103,12 @@ public class ExportRepresentationCommand extends RecordingCommand {
         if (this.layers.isEmpty() && this.representation instanceof DDiagram) {
             this.exportedDiagram = (DDiagram) this.representation;
         } else {
-            CompoundCommand compoundCmd = new CompoundCommand();
+            Command compoundCmd;
             // copy representation
             this.exportedDiagram = (DDiagram) DialectManager.INSTANCE.copyRepresentation(this.representation,
                     this.representation.getName() + SUFFIXE_COPY, session, MONITOR);
             // activate layers list.
-            compoundCmd.append(activateLayers(this.exportedDiagram));
+            compoundCmd = activateLayers(this.exportedDiagram);
             if (!isRepresentationOpened) {
                 new GMFDiagramUpdater(session, (DDiagram) representation);
             }

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
@@ -83,10 +83,10 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
      *            the Sirius session from which we want to find the representation with the given name.
      * @return all representations whose target is the specified EObject
      */
-    private List<DRepresentation> getAssociatedRepresentationByDiagramDescriptionAndName(Generation generation,
-            EObject targetRootObject, String diagramId, Session session, boolean createIfAbsent) {
+    private List<DRepresentation> getAssociatedRepresentationByDiagramDescriptionName(Generation generation,
+            EObject targetRootObject, String diagramDescriptionName, Session session, boolean createIfAbsent) {
         List<DRepresentation> result = new ArrayList<DRepresentation>();
-        if (diagramId != null) {
+        if (diagramDescriptionName != null) {
             Collection<DRepresentation> representations = DialectManager.INSTANCE.getRepresentations(targetRootObject,
                     session);
             // Filter representations to keep only those in a selected viewpoint
@@ -94,7 +94,7 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
 
             for (DRepresentation representation : representations) {
                 if (representation instanceof DDiagram
-                    && diagramId.equals(((DDiagram) representation).getDescription().getName())
+                    && diagramDescriptionName.equals(((DDiagram) representation).getDescription().getName())
                     && representation.eContainer() instanceof DView) {
                     DView dView = (DView) representation.eContainer();
                     Viewpoint vp = dView.getViewpoint();
@@ -105,9 +105,9 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
             }
         }
         if (result.isEmpty() && createIfAbsent) {
-            RepresentationDescription description = findDiagramDescription(session, diagramId);
+            RepresentationDescription description = findDiagramDescription(session, diagramDescriptionName);
             session.getTransactionalEditingDomain().getCommandStack().execute(new CreateRepresentationCommand(session,
-                    description, targetRootObject, diagramId, new NullProgressMonitor()));
+                    description, targetRootObject, diagramDescriptionName, new NullProgressMonitor()));
             for (DRepresentation representation : DialectManager.INSTANCE.getRepresentations(targetRootObject,
                     session)) {
                 if (representation instanceof DDiagram && ((DDiagram) representation).getDescription() == description) {
@@ -146,7 +146,7 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
                 throw new ProviderException("Cannot find session associated to the conf model root element.");
             }
             checkDiagramDescriptionExist(session, (String) diagramDescriptionName);
-            List<DRepresentation> representations = getAssociatedRepresentationByDiagramDescriptionAndName(generation,
+            List<DRepresentation> representations = getAssociatedRepresentationByDiagramDescriptionName(generation,
                     targetRootEObject, (String) diagramDescriptionName, session, createIfAbsent);
             if (!representations.isEmpty() && representations.get(0) instanceof DDiagram) {
                 return generateAndReturnDiagramImages(rootPath, session, representations,

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
@@ -19,9 +19,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.business.api.dialect.DialectManager;
+import org.eclipse.sirius.business.api.dialect.command.CreateRepresentationCommand;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.diagram.DDiagram;
@@ -30,11 +32,14 @@ import org.eclipse.sirius.viewpoint.DRepresentation;
 import org.eclipse.sirius.viewpoint.DView;
 import org.eclipse.sirius.viewpoint.description.RepresentationDescription;
 import org.eclipse.sirius.viewpoint.description.Viewpoint;
+import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.provider.IProvider;
 import org.obeonetwork.m2doc.provider.OptionType;
 import org.obeonetwork.m2doc.provider.ProviderConstants;
 import org.obeonetwork.m2doc.provider.ProviderException;
 import org.obeonetwork.m2doc.provider.ProviderValidationMessage;
+import org.obeonetwork.m2doc.sirius.session.CleaningAIRDJob;
+import org.obeonetwork.m2doc.sirius.session.CleaningJobRegistry;
 
 /**
  * {@link SiriusDiagramByDiagramDescriptionNameProvider} are used to get Sirius diagrams images from all representations using a given root
@@ -52,6 +57,14 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
      * representation title from which image will be computed.
      */
     private static final String DIAGRAM_DESCRIPTION_ID_KEY = "descriptionId";
+    /**
+     * the key used in the map passed to {@link IProvider} to define the value of the create option.
+     */
+    private static final String CREATE_ID_KEY = "create";
+    /**
+     * Value used to assert absent representation must be created.
+     */
+    private static final Object CREATE_VALUE = "true";
 
     /**
      * Default constructor.
@@ -64,25 +77,24 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
      * 
      * @param targetRootObject
      *            Object which is the target of the representations.
-     * @param diagramDescriptionName
+     * @param diagramId
      *            the diagram description from which we want to retrieve representations.
      * @param session
      *            the Sirius session from which we want to find the representation with the given name.
      * @return all representations whose target is the specified EObject
      */
-    private List<DRepresentation> getAssociatedRepresentationByDiagramDescriptionAndName(EObject targetRootObject,
-            String diagramDescriptionName, Session session) {
+    private List<DRepresentation> getAssociatedRepresentationByDiagramDescriptionAndName(Generation generation,
+            EObject targetRootObject, String diagramId, Session session, boolean createIfAbsent) {
         List<DRepresentation> result = new ArrayList<DRepresentation>();
-        if (diagramDescriptionName != null) {
+        if (diagramId != null) {
             Collection<DRepresentation> representations = DialectManager.INSTANCE.getRepresentations(targetRootObject,
                     session);
-
             // Filter representations to keep only those in a selected viewpoint
             Collection<Viewpoint> selectedViewpoints = session.getSelectedViewpoints(false);
 
             for (DRepresentation representation : representations) {
                 if (representation instanceof DDiagram
-                    && diagramDescriptionName.equals(((DDiagram) representation).getDescription().getName())
+                    && diagramId.equals(((DDiagram) representation).getDescription().getName())
                     && representation.eContainer() instanceof DView) {
                     DView dView = (DView) representation.eContainer();
                     Viewpoint vp = dView.getViewpoint();
@@ -92,16 +104,31 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
                 }
             }
         }
+        if (result.isEmpty() && createIfAbsent) {
+            RepresentationDescription description = findDiagramDescription(session, diagramId);
+            session.getTransactionalEditingDomain().getCommandStack().execute(new CreateRepresentationCommand(session,
+                    description, targetRootObject, diagramId, new NullProgressMonitor()));
+            for (DRepresentation representation : DialectManager.INSTANCE.getRepresentations(targetRootObject,
+                    session)) {
+                if (representation instanceof DDiagram && ((DDiagram) representation).getDescription() == description) {
+                    CleaningJobRegistry.INSTANCE.registerJob(generation,
+                            new CleaningAIRDJob(targetRootObject, session, representation));
+                    result = Lists.newArrayList(representation);
+                }
+            }
 
+        }
         return result;
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<String> getRepresentationImagePath(Map<String, Object> parameters) throws ProviderException {
+        Generation generation = (Generation) parameters.get(ProviderConstants.CONF_ROOT_OBJECT_KEY);
         String rootPath = (String) parameters.get(ProviderConstants.PROJECT_ROOT_PATH_KEY);
         Object diagramDescriptionName = parameters.get(DIAGRAM_DESCRIPTION_ID_KEY);
         Object targetRootObject = parameters.get(TARGET_ROOT_OBJECT_KEY);
+        boolean createIfAbsent = CREATE_VALUE.equals(parameters.get(CREATE_ID_KEY));
         List<String> diagramActivatedLayers = (List<String>) parameters
                 .get(ProviderConstants.DIAGRAM_ACTIVATED_LAYERS_KEY);
         if (!(diagramDescriptionName instanceof String)) {
@@ -119,14 +146,36 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
                 throw new ProviderException("Cannot find session associated to the conf model root element.");
             }
             checkDiagramDescriptionExist(session, (String) diagramDescriptionName);
-            List<DRepresentation> representations = getAssociatedRepresentationByDiagramDescriptionAndName(
-                    targetRootEObject, (String) diagramDescriptionName, session);
+            List<DRepresentation> representations = getAssociatedRepresentationByDiagramDescriptionAndName(generation,
+                    targetRootEObject, (String) diagramDescriptionName, session, createIfAbsent);
             if (!representations.isEmpty() && representations.get(0) instanceof DDiagram) {
                 return generateAndReturnDiagramImages(rootPath, session, representations,
                         getLayers((DDiagram) representations.get(0), diagramActivatedLayers));
             }
             return generateAndReturnDiagramImages(rootPath, session, representations, Lists.<Layer> newArrayList());
         }
+    }
+
+    /**
+     * Returns the specified diagram representation.
+     * 
+     * @param session
+     * @param diagramDescriptionName
+     * @return
+     * @throws ProviderException
+     *             if the specified representation doesn't exist.
+     */
+    private RepresentationDescription findDiagramDescription(Session session, String diagramDescriptionName) {
+        Collection<Viewpoint> selectedViewpoints = session.getSelectedViewpoints(false);
+        for (Viewpoint viewpoint : selectedViewpoints) {
+            EList<RepresentationDescription> ownedRepresentations = viewpoint.getOwnedRepresentations();
+            for (RepresentationDescription representationDescription : ownedRepresentations) {
+                if (diagramDescriptionName.equals(representationDescription.getName())) {
+                    return representationDescription;
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -140,17 +189,7 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
      *             if the diagram description does not exist in the session.
      */
     private void checkDiagramDescriptionExist(Session session, String diagramDescriptionName) throws ProviderException {
-        boolean diagramDescriptionExist = false;
-        Collection<Viewpoint> selectedViewpoints = session.getSelectedViewpoints(false);
-        for (Viewpoint viewpoint : selectedViewpoints) {
-            EList<RepresentationDescription> ownedRepresentations = viewpoint.getOwnedRepresentations();
-            for (RepresentationDescription representationDescription : ownedRepresentations) {
-                if (diagramDescriptionName.equals(representationDescription.getName())) {
-                    diagramDescriptionExist = true;
-                }
-            }
-        }
-        if (!diagramDescriptionExist) {
+        if (findDiagramDescription(session, diagramDescriptionName) == null) {
             throw new ProviderException("The provided diagram description '" + diagramDescriptionName
                 + "' does not exist in the loaded aird");
         }

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/CleaningAIRDJob.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/CleaningAIRDJob.java
@@ -1,0 +1,59 @@
+package org.obeonetwork.m2doc.sirius.session;
+
+import com.google.common.collect.Sets;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.business.api.dialect.command.DeleteRepresentationCommand;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.viewpoint.DRepresentation;
+
+/**
+ * Cleaning Job Info contains the necessary information to clean a representation.
+ * 
+ * @author Romain Guider
+ */
+public class CleaningAIRDJob implements ICleaningJob {
+
+    /**
+     * The semantic object associated with the representation.
+     */
+    private EObject semantic;
+    /**
+     * The session where the representation has been created and must be deleted.
+     */
+    private Session session;
+    /**
+     * The representation that must be cleaned.
+     */
+    private DRepresentation representation;
+
+    /**
+     * Create a new {@link CleaningAIRDJob} instance given a semantic object a session and a representation.
+     * 
+     * @param semantic
+     *            the semantic object
+     * @param session
+     *            the session.
+     * @param representation
+     *            the representation to delete.
+     */
+    public CleaningAIRDJob(EObject semantic, Session session, DRepresentation representation) {
+        this.semantic = semantic;
+        this.session = session;
+        this.representation = representation;
+    }
+
+    /**
+     * delete the representation.
+     */
+    @Override
+    public void doClean() {
+        session.getTransactionalEditingDomain().getCommandStack()
+                .execute(new DeleteRepresentationCommand(session, Sets.newHashSet(representation)));
+    }
+
+    @Override
+    public Session getSession() {
+        return session;
+    }
+}

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/CleaningAIRDJob.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/CleaningAIRDJob.java
@@ -8,24 +8,24 @@ import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.viewpoint.DRepresentation;
 
 /**
- * Cleaning Job Info contains the necessary information to clean a representation.
+ * A {@link CleaningAIRDJob} contains the necessary information to clean a representation after generation.
  * 
  * @author Romain Guider
  */
-public class CleaningAIRDJob implements ICleaningJob {
+public class CleaningAIRDJob implements Runnable {
 
     /**
      * The semantic object associated with the representation.
      */
-    private EObject semantic;
+    private final EObject semantic;
     /**
      * The session where the representation has been created and must be deleted.
      */
-    private Session session;
+    private final Session session;
     /**
      * The representation that must be cleaned.
      */
-    private DRepresentation representation;
+    private final DRepresentation representation;
 
     /**
      * Create a new {@link CleaningAIRDJob} instance given a semantic object a session and a representation.
@@ -38,6 +38,9 @@ public class CleaningAIRDJob implements ICleaningJob {
      *            the representation to delete.
      */
     public CleaningAIRDJob(EObject semantic, Session session, DRepresentation representation) {
+        if (semantic == null || session == null || representation == null) {
+            throw new IllegalArgumentException("a null argument has been passed to the CleaningAIRDJob constructor");
+        }
         this.semantic = semantic;
         this.session = session;
         this.representation = representation;
@@ -47,13 +50,9 @@ public class CleaningAIRDJob implements ICleaningJob {
      * delete the representation.
      */
     @Override
-    public void doClean() {
+    public void run() {
         session.getTransactionalEditingDomain().getCommandStack()
                 .execute(new DeleteRepresentationCommand(session, Sets.newHashSet(representation)));
     }
 
-    @Override
-    public Session getSession() {
-        return session;
-    }
 }

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/CleaningJobRegistry.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/CleaningJobRegistry.java
@@ -1,0 +1,65 @@
+package org.obeonetwork.m2doc.sirius.session;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+
+import org.obeonetwork.m2doc.genconf.Generation;
+
+/**
+ * Register of cleaning jobs.
+ * 
+ * @author Romain Guider
+ */
+public class CleaningJobRegistry {
+    /**
+     * the singleton instance of {@link CleaningJobRegistry}.
+     */
+    public static final CleaningJobRegistry INSTANCE = new CleaningJobRegistry();
+    /**
+     * The map where jobs are stored.
+     */
+    private Map<Generation, List<ICleaningJob>> jobs;
+
+    /**
+     * hiden constructor.
+     */
+    protected CleaningJobRegistry() {
+        jobs = Maps.newHashMap();
+    }
+
+    /**
+     * Registers a job on a generation.
+     * 
+     * @param generation
+     *            the generation
+     * @param job
+     *            the job
+     */
+    public void registerJob(Generation generation, ICleaningJob job) {
+        List<ICleaningJob> genJobs = jobs.get(generation);
+        if (genJobs == null) {
+            genJobs = Lists.newArrayList();
+            jobs.put(generation, genJobs);
+        }
+        genJobs.add(job);
+    }
+
+    /**
+     * Clears all the jobs associated to a generation.
+     * 
+     * @param generation
+     *            the generation.
+     */
+    public void clean(Generation generation) {
+        List<ICleaningJob> genJobs = jobs.get(generation);
+        if (genJobs != null) {
+            for (ICleaningJob job : genJobs) {
+                job.doClean();
+            }
+        }
+    }
+
+}

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/ICleaningJob.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/ICleaningJob.java
@@ -1,0 +1,22 @@
+package org.obeonetwork.m2doc.sirius.session;
+
+import org.eclipse.sirius.business.api.session.Session;
+
+/**
+ * This interface provides a common API to all the cleanup jobs that must be executed after a generation finished.
+ * 
+ * @author Romain Guider
+ */
+public interface ICleaningJob {
+    /**
+     * Triggers the cleaning job.
+     */
+    void doClean();
+
+    /**
+     * Returns the Sirius session in which the Job has been created.
+     * 
+     * @return
+     */
+    Session getSession();
+}

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/SessionCleaner.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/SessionCleaner.java
@@ -1,0 +1,60 @@
+package org.obeonetwork.m2doc.sirius.session;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.obeonetwork.m2doc.genconf.Generation;
+import org.obeonetwork.m2doc.generator.DocumentGenerator;
+import org.obeonetwork.m2doc.generator.TemplateGenerator;
+import org.obeonetwork.m2doc.properties.TemplateInfo;
+import org.obeonetwork.m2doc.provider.configuration.IConfigurationProvider;
+import org.obeonetwork.m2doc.template.DocumentTemplate;
+
+/**
+ * The {@link SessionCleaner} is used to clean up the Sirius Session after M2Doc generation finishes.
+ * The representations that were created during generation must be destroyed so as to leave the aird unchanged.
+ * 
+ * @author Romain Guider
+ */
+public class SessionCleaner implements IConfigurationProvider {
+
+    @Override
+    public void postCreateConfigurationModel(TemplateInfo templateInfo, IFile templateFile, Generation generation) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void preCreateConfigurationModel(TemplateInfo templateInfo, IFile templateFile) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean postValidateTemplate(IFile templateFile, DocumentTemplate template, Generation generation,
+            TemplateGenerator generator) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void preValidateTemplate(IFile templateFile, DocumentTemplate template, Generation generation) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void preGenerate(Generation generation, IProject project, IFile templateFile, IFile generatedFile) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public List<IFile> postGenerate(Generation generation, IProject project, IFile templateFile, IFile generatedFile,
+            DocumentTemplate template, DocumentGenerator generator) {
+        CleaningJobRegistry.INSTANCE.clean(generation);
+        return null;
+    }
+
+}

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/SessionCleaner.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/SessionCleaner.java
@@ -1,5 +1,6 @@
 package org.obeonetwork.m2doc.sirius.session;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -21,40 +22,37 @@ public class SessionCleaner implements IConfigurationProvider {
 
     @Override
     public void postCreateConfigurationModel(TemplateInfo templateInfo, IFile templateFile, Generation generation) {
-        // TODO Auto-generated method stub
+        // unused.
 
     }
 
     @Override
     public void preCreateConfigurationModel(TemplateInfo templateInfo, IFile templateFile) {
-        // TODO Auto-generated method stub
-
+        // unused.
     }
 
     @Override
     public boolean postValidateTemplate(IFile templateFile, DocumentTemplate template, Generation generation,
             TemplateGenerator generator) {
-        // TODO Auto-generated method stub
+        // unused.
         return false;
     }
 
     @Override
     public void preValidateTemplate(IFile templateFile, DocumentTemplate template, Generation generation) {
-        // TODO Auto-generated method stub
-
+        // unused.
     }
 
     @Override
     public void preGenerate(Generation generation, IProject project, IFile templateFile, IFile generatedFile) {
-        // TODO Auto-generated method stub
-
+        // unused.
     }
 
     @Override
     public List<IFile> postGenerate(Generation generation, IProject project, IFile templateFile, IFile generatedFile,
             DocumentTemplate template, DocumentGenerator generator) {
         CleaningJobRegistry.INSTANCE.clean(generation);
-        return null;
+        return Collections.emptyList();
     }
 
 }

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/parser/BodyParser.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/parser/BodyParser.java
@@ -121,6 +121,10 @@ public class BodyParser {
      */
     private static final String PROVIDER_KEY = "provider";
     /**
+     * Diagram or table create option name.
+     */
+    private static final String CREATE_KEY = "create";
+    /**
      * Diagram layers option name.
      */
     private static final String DIAGRAM_LAYERS_KEY = "layers";
@@ -160,7 +164,7 @@ public class BodyParser {
     private static final String[] DIAGRAM_OPTION_SET =
 
             {PROVIDER_KEY, IMAGE_HEIGHT_KEY, IMAGE_LEGEND_KEY, IMAGE_LEGEND_POSITION, IMAGE_WIDTH_KEY,
-                DIAGRAM_LAYERS_KEY, };
+                DIAGRAM_LAYERS_KEY, CREATE_KEY, };
 
     /**
      * Rank of the option's value group in the matcher.
@@ -746,6 +750,8 @@ public class BodyParser {
                 } else {
                     providerTemplate.getOptionValueMap().put(parsedOption.getKey(), parsedOption.getValue());
                 }
+            } else if (CREATE_KEY.equals(parsedOption.getKey())) {
+                providerTemplate.getOptionValueMap().put(parsedOption.getKey(), parsedOption.getValue());
             }
         }
     }
@@ -812,6 +818,7 @@ public class BodyParser {
         optionToIgnore.add(IMAGE_WIDTH_KEY);
         optionToIgnore.add(PROVIDER_KEY);
         optionToIgnore.add(DIAGRAM_LAYERS_KEY);
+        optionToIgnore.add(CREATE_KEY);
         if (representation.getProvider() != null) {
             setGenericOptions(representation, options, optionToIgnore, representation.getProvider());
         }
@@ -870,9 +877,11 @@ public class BodyParser {
         if (providerQualifiedName != null) {
             result = ProviderRegistry.INSTANCE.getProvider(providerQualifiedName);
             if (result == null) {
-            	representation.getValidationMessages().add(new TemplateValidationMessage(ValidationMessageLevel.ERROR,
-                        String.format("The image tag is referencing an unknown diagram provider : '%s'", providerQualifiedName),
-                        representation.getRuns().get(1)));
+                representation.getValidationMessages()
+                        .add(new TemplateValidationMessage(ValidationMessageLevel.ERROR,
+                                String.format("The image tag is referencing an unknown diagram provider : '%s'",
+                                        providerQualifiedName),
+                                representation.getRuns().get(1)));
                 return null;
             }
         }
@@ -936,7 +945,7 @@ public class BodyParser {
             } else {
                 // let's find the best provider
                 for (AbstractTableProvider provider : providers) {
-                    if (OptionChecker.check(provider.getOptionTypes()).ignore(PROVIDER_KEY, HIDE_TITLE_KEY)
+                    if (OptionChecker.check(provider.getOptionTypes()).ignore(PROVIDER_KEY, HIDE_TITLE_KEY, CREATE_KEY)
                             .against(options)) {
                         tableClient.setProvider(provider);
                         setGenericOptions(tableClient, options, ImmutableSet.of(PROVIDER_KEY), provider);


### PR DESCRIPTION
Two commits : 
- a simple one that cleans up a unused compound command
- another one that introduces the capacity for creating representations on the fly to insert them in generated doc and cleaning them from the session.

