### PR TITLE
Fix regression introduced in 'Fixed M2Doc to be a singleton'

### DIFF
--- a/plugins/org.obeonetwork.m2doc.ide/src/org/obeonetwork/m2doc/ide/services/DeclaredServicesListener.java
+++ b/plugins/org.obeonetwork.m2doc.ide/src/org/obeonetwork/m2doc/ide/services/DeclaredServicesListener.java
@@ -32,7 +32,7 @@ public class DeclaredServicesListener implements IRegistryEventListener {
     /**
      * Unique ID of the extension point.
      */
-    private static final String SERVICEREGISTERY_ID = "org.obeonetwork.m2doc.services.register";
+    private static final String SERVICEREGISTERY_ID = "org.obeonetwork.m2doc.ide.services.register";
     /**
      * Name of the service element.
      */


### PR DESCRIPTION
The constant that represents the extension point for declared services
hadn't been refactored to reflect the new ID of the extension point.

Change-Id: I8ca654240589deae12ebc6c430bec2c473c74617