### PR TITLE
Add possibility to select the image type if the URI has no file exten…

### DIFF
--- a/plugins/org.obeonetwork.m2doc.genconf/META-INF/MANIFEST.MF
+++ b/plugins/org.obeonetwork.m2doc.genconf/META-INF/MANIFEST.MF
@@ -17,7 +17,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.obeonetwork.m2doc.tplconf;bundle-version="[0.10.0,0.11.0)",
  org.eclipse.acceleo.query;bundle-version="[5.0.0,6.0.0)",
  org.obeonetwork.m2doc;bundle-version="[0.10.0,0.11.0)",
- org.eclipse.acceleo.query;bundle-version="[5.0.0,6.0.0)",
- org.obeonetwork.m2doc;bundle-version="[0.10.0,0.11.0)",
  org.eclipse.emf.ecore.xmi
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.obeonetwork.m2doc.sirius/META-INF/MANIFEST.MF
+++ b/plugins/org.obeonetwork.m2doc.sirius/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.obeonetwork.m2doc;bundle-version="[0.10.0,0.11.0)",
  com.google.guava;bundle-version="[15.0.0,16.0.0)",
  org.obeonetwork.m2doc.genconf;bundle-version="[0.10.0,0.11.0)",
- org.eclipse.sirius.common;bundle-version="4.1.4"
+ org.eclipse.sirius.common;bundle-version="[4.1.0,5.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: org.obeonetwork.m2doc.sirius.commands,

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/api/Image.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/api/Image.java
@@ -19,6 +19,7 @@ import javax.imageio.ImageIO;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.URIConverter;
+import org.obeonetwork.m2doc.util.PictureType;
 
 /**
  * An image that can be returned by services.
@@ -53,13 +54,35 @@ public class Image {
     private double ratio;
 
     /**
-     * Constructor.
+     * The type.
+     */
+    private PictureType type;
+
+    /**
+     * Default constructor.
+     * <p>
+     * The image type is deducted from the image {@link URI} file extension. If the extension is unknown, jpeg format will be selected by
+     * default.
+     * </p>
      * 
      * @param uri
      *            the {@link URI}
      */
     public Image(URI uri) {
+        this(uri, PictureType.toType(uri));
+    }
+
+    /**
+     * Constructor with enforced image type.
+     * 
+     * @param uri
+     *            the {@link URI}
+     * @param type
+     *            the picture {@link PictureType type}.
+     */
+    public Image(URI uri, PictureType type) {
         this.uri = uri;
+        this.type = type;
         try {
             final BufferedImage image = ImageIO.read(getInputStream());
             if (image != null) {
@@ -170,6 +193,15 @@ public class Image {
      */
     public InputStream getInputStream() throws IOException {
         return URIConverter.INSTANCE.createInputStream(uri);
+    }
+
+    /**
+     * Gets the {@link PictureType}.
+     * 
+     * @return the type the {@link PictureType}.
+     */
+    public PictureType getType() {
+        return type;
     }
 
     @Override

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/M2DocEvaluator.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/M2DocEvaluator.java
@@ -30,7 +30,6 @@ import java.util.Stack;
 
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.util.Units;
-import org.apache.poi.xwpf.usermodel.Document;
 import org.apache.poi.xwpf.usermodel.IBody;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFFooter;
@@ -87,6 +86,7 @@ import org.obeonetwork.m2doc.template.UserContent;
 import org.obeonetwork.m2doc.template.UserDoc;
 import org.obeonetwork.m2doc.template.util.TemplateSwitch;
 import org.obeonetwork.m2doc.util.M2DocUtils;
+import org.obeonetwork.m2doc.util.PictureType;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTHdrFtr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTHyperlink;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
@@ -502,7 +502,7 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
             int width = Units.toEMU(image.getWidth());
 
             try (InputStream imageStream = image.getInputStream()) {
-                run.addPicture(imageStream, getPictureType(image.getURI()), image.getURI().toString(), width, heigth);
+                run.addPicture(imageStream, image.getType().getPoiType(), image.getURI().toString(), width, heigth);
             }
         } catch (InvalidFormatException e) {
             insertMessage(currentGeneratedParagraph, ValidationMessageLevel.ERROR,
@@ -857,48 +857,6 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
         return null;
     }
 
-    /**
-     * Returns the picture type based on the filename's extension.
-     * 
-     * @param fileName
-     *            the picture file
-     * @return the picture's file extension
-     */
-    private int getPictureType(URI fileName) {
-        int res;
-        if (fileName.fileExtension() != null) {
-            String extension = fileName.fileExtension();
-            if ("jpg".equalsIgnoreCase(extension) || "jpeg".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_JPEG;
-            } else if ("gif".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_GIF;
-            } else if ("png".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_PNG;
-            } else if ("emf".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_EMF;
-            } else if ("wmf".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_WMF;
-            } else if ("pict".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_PICT;
-            } else if ("dib".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_DIB;
-            } else if ("tiff".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_TIFF;
-            } else if ("eps".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_EPS;
-            } else if ("bmp".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_BMP;
-            } else if ("wpg".equalsIgnoreCase(extension)) {
-                res = Document.PICTURE_TYPE_WPG;
-            } else {
-                res = 0;
-            }
-        } else {
-            res = 0;
-        }
-        return res;
-    }
-
     @Override
     public IConstruct caseImage(Image image) {
         XWPFRun imageRun = insertRun(image.getStyleRun());
@@ -922,7 +880,8 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
                 int width = Units.toEMU(image.getWidth());
 
                 try (InputStream imageStream = URIConverter.INSTANCE.createInputStream(imageURI)) {
-                    imageRun.addPicture(imageStream, getPictureType(imageURI), image.getFileName(), width, heigth);
+                    imageRun.addPicture(imageStream, PictureType.toType(imageURI).getPoiType(), image.getFileName(),
+                            width, heigth);
                 }
             } catch (InvalidFormatException e) {
                 insertMessage(currentGeneratedParagraph, ValidationMessageLevel.ERROR,

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/services/ImageServices.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/services/ImageServices.java
@@ -20,6 +20,7 @@ import org.eclipse.acceleo.annotations.api.documentation.Param;
 import org.eclipse.acceleo.annotations.api.documentation.ServiceProvider;
 import org.eclipse.emf.common.util.URI;
 import org.obeonetwork.m2doc.api.Image;
+import org.obeonetwork.m2doc.util.PictureType;
 
 //@formatter:off
 @ServiceProvider(
@@ -56,14 +57,45 @@ public class ImageServices {
         }
     )
     // @formatter:on
+
     /**
      * Gets the {@link Image} corresponding to the given path.
+     * <p>
+     * Picture type is deducted from the file extension.
+     * </p>
      * 
-     * @param path
-     *            the path
+     * @param uriStr
+     *            the uri.
      * @return the {@link Image} corresponding to the given path
      */
     public Image asImage(String uriStr) {
+        final URI imageURI = URI.createURI(uriStr);
+        return asImage(uriStr, PictureType.toType(imageURI));
+    }
+
+    /**
+     * Gets the {@link Image} corresponding to the given path.
+     * 
+     * @param uriStr
+     *            the uri.
+     * @param type
+     *            the picture {@link PictureType type}.
+     * @return the {@link Image} corresponding to the given path
+     */
+    public Image asImage(String uriStr, String type) {
+        return asImage(uriStr, PictureType.valueOf(type.toUpperCase()));
+    }
+
+    /**
+     * Gets the {@link Image} corresponding to the given path.
+     * 
+     * @param uriStr
+     *            the uri.
+     * @param type
+     *            the picture {@link PictureType type}.
+     * @return the {@link Image} corresponding to the given path
+     */
+    private Image asImage(String uriStr, PictureType type) {
         final Image res;
 
         final URI imageURI = URI.createURI(uriStr);
@@ -80,7 +112,7 @@ public class ImageServices {
         } else {
             uri = imageURI;
         }
-        res = new Image(uri);
+        res = new Image(uri, type);
 
         return res;
     }

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/util/PictureType.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/util/PictureType.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 Obeo. 
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *   
+ *   Contributors:
+ *       Obeo - initial API and implementation
+ *  
+ *******************************************************************************/
+package org.obeonetwork.m2doc.util;
+
+import org.apache.poi.xwpf.usermodel.Document;
+import org.eclipse.emf.common.util.URI;
+
+/**
+ * Picture types.
+ * 
+ * @author <a href="mailto:jean-francois.brazeau@obeo.fr">Jean-Francois Brazeau</a>
+ */
+public enum PictureType {
+
+    /*** Bitmap format. */
+    BMP(Document.PICTURE_TYPE_BMP),
+
+    /*** DIB format. */
+    DIB(Document.PICTURE_TYPE_DIB),
+
+    /*** EMF format. */
+    EMF(Document.PICTURE_TYPE_EMF),
+
+    /*** EPS format. */
+    EPS(Document.PICTURE_TYPE_EPS),
+
+    /*** GIF format. */
+    GIF(Document.PICTURE_TYPE_GIF),
+
+    /*** JPEG format. */
+    JPG(Document.PICTURE_TYPE_JPEG),
+
+    /*** JPG format. */
+    JPEG(Document.PICTURE_TYPE_JPEG),
+
+    /*** PICT format. */
+    PICT(Document.PICTURE_TYPE_PICT),
+
+    /*** PNG format. */
+    PNG(Document.PICTURE_TYPE_PNG),
+
+    /*** TIFF format. */
+    TIFF(Document.PICTURE_TYPE_TIFF),
+
+    /*** WMF format. */
+    WMF(Document.PICTURE_TYPE_WMF),
+
+    /*** WPG format. */
+    WPG(Document.PICTURE_TYPE_WPG);
+
+    /**
+     * The picture type according to POI.
+     */
+    private int poiType;
+
+    /**
+     * Default constructor.
+     * 
+     * @param poiType
+     *            the POI type.
+     */
+    PictureType(int poiType) {
+        this.poiType = poiType;
+    }
+
+    /**
+     * Return the picture type value according to POI.
+     * 
+     * @return the poiType the POI picture type.
+     * @see Document
+     */
+    public int getPoiType() {
+        return poiType;
+    }
+
+    /**
+     * Returns the image type based on the filename's extension.
+     * 
+     * @param pictureURI
+     *            the picture {@link URI}.
+     * @return the picture type.
+     */
+    public static PictureType toType(URI pictureURI) {
+        PictureType res = null;
+        if (pictureURI.fileExtension() != null) {
+            String extension = pictureURI.fileExtension();
+            try {
+                res = valueOf(extension.toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // Simply ignore this exception. It means that the
+                // given extension is unknown.
+                // JPG type will be returned by default.
+            }
+        }
+        // By default, fallback to JPG format
+        if (res == null) {
+            res = JPG;
+        }
+        return res;
+    }
+
+}


### PR DESCRIPTION
Add possibility to select the image type if the URI has no file extension + default image type is set to JPG instead of 0 (which leads in all cases to a failure)

More details : in a template it is possible to insert an image by simply selecting an image URI which is very powerful. Unfortunately, 2 problems may persist when using such system :
* the first is that the URI may not contain any file extension (if it is binded to a specific protocol in which file extension has no meaning) so that m2doc is not able to detect the image type
* the second is that in such case, m2doc selects a 0 value for the PO type which leads to a NPE failure ; it should be more relevant to select at least a valid value by default (ex : JPG ?)