### PR TITLE
Use distinct resourcesets for the genconf and for the input models

### DIFF
--- a/plugins/org.obeonetwork.m2doc.genconf.edit/plugin.properties
+++ b/plugins/org.obeonetwork.m2doc.genconf.edit/plugin.properties
@@ -45,3 +45,4 @@ _UI_Unknown_feature = Unspecified
 
 _UI_ModelDefinition_type_feature = Type
 _UI_Generation_refreshRepresentations_feature = Refresh Representations
+_UI_Generation_representationsFileName_feature = Representations File Name

--- a/plugins/org.obeonetwork.m2doc.genconf.edit/src-gen/org/obeonetwork/m2doc/genconf/provider/GenerationItemProvider.java
+++ b/plugins/org.obeonetwork.m2doc.genconf.edit/src-gen/org/obeonetwork/m2doc/genconf/provider/GenerationItemProvider.java
@@ -66,6 +66,7 @@ public class GenerationItemProvider
             addNamePropertyDescriptor(object);
             addTemplateFileNamePropertyDescriptor(object);
             addResultFileNamePropertyDescriptor(object);
+            addRepresentationsFileNamePropertyDescriptor(object);
             addTimeStampedPropertyDescriptor(object);
             addRefreshRepresentationsPropertyDescriptor(object);
         }
@@ -139,6 +140,28 @@ public class GenerationItemProvider
     }
 
 	/**
+     * This adds a property descriptor for the Representations File Name feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    protected void addRepresentationsFileNamePropertyDescriptor(Object object) {
+        itemPropertyDescriptors.add
+            (createItemPropertyDescriptor
+                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+                 getResourceLocator(),
+                 getString("_UI_Generation_representationsFileName_feature"),
+                 getString("_UI_PropertyDescriptor_description", "_UI_Generation_representationsFileName_feature", "_UI_Generation_type"),
+                 GenconfPackage.Literals.GENERATION__REPRESENTATIONS_FILE_NAME,
+                 true,
+                 false,
+                 false,
+                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+                 null,
+                 null));
+    }
+
+    /**
      * This adds a property descriptor for the Time Stamped feature.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -263,6 +286,7 @@ public class GenerationItemProvider
             case GenconfPackage.GENERATION__NAME:
             case GenconfPackage.GENERATION__TEMPLATE_FILE_NAME:
             case GenconfPackage.GENERATION__RESULT_FILE_NAME:
+            case GenconfPackage.GENERATION__REPRESENTATIONS_FILE_NAME:
             case GenconfPackage.GENERATION__TIME_STAMPED:
             case GenconfPackage.GENERATION__REFRESH_REPRESENTATIONS:
                 fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));

--- a/plugins/org.obeonetwork.m2doc.genconf/META-INF/MANIFEST.MF
+++ b/plugins/org.obeonetwork.m2doc.genconf/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Require-Bundle: org.eclipse.core.runtime,
  com.google.guava;bundle-version="[15.0.0,16.0.0)",
  org.obeonetwork.m2doc.tplconf;bundle-version="[0.10.0,0.11.0)",
  org.eclipse.acceleo.query;bundle-version="[6.0.0,7.0.0)",
- org.obeonetwork.m2doc;bundle-version="[0.10.0,0.11.0)"
+ org.obeonetwork.m2doc;bundle-version="[0.10.0,0.11.0)",
+ org.eclipse.emf.ecore.xmi
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.obeonetwork.m2doc.genconf/model/m2docconf.ecore
+++ b/plugins/org.obeonetwork.m2doc.genconf/model/m2docconf.ecore
@@ -6,10 +6,12 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="templateFileName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="resultFileName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="representationsFileName"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timeStamped" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
         defaultValueLiteral="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="refreshRepresentations"
-        eType="ecore:EDataType platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EBoolean"
+        eType="ecore:EDataType ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EBoolean"
         defaultValueLiteral="false"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="definitions" upperBound="-1"
         eType="#//Definition" containment="true"/>
@@ -19,7 +21,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ModelDefinition" eSuperTypes="#//Definition">
     <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EClassifier"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EClassifier"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="StringDefinition" eSuperTypes="#//Definition">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/plugins/org.obeonetwork.m2doc.genconf/model/m2docconf.genmodel
+++ b/plugins/org.obeonetwork.m2doc.genconf/model/m2docconf.genmodel
@@ -13,6 +13,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute m2docconf.ecore#//Generation/name"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute m2docconf.ecore#//Generation/templateFileName"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute m2docconf.ecore#//Generation/resultFileName"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute m2docconf.ecore#//Generation/representationsFileName"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute m2docconf.ecore#//Generation/timeStamped"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute m2docconf.ecore#//Generation/refreshRepresentations"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference m2docconf.ecore#//Generation/definitions"/>

--- a/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/GenconfPackage.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/GenconfPackage.java
@@ -94,13 +94,22 @@ public interface GenconfPackage extends EPackage {
 	int GENERATION__RESULT_FILE_NAME = 2;
 
 	/**
+     * The feature id for the '<em><b>Representations File Name</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     * @ordered
+     */
+    int GENERATION__REPRESENTATIONS_FILE_NAME = 3;
+
+    /**
      * The feature id for the '<em><b>Time Stamped</b></em>' attribute.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      * @ordered
      */
-	int GENERATION__TIME_STAMPED = 3;
+	int GENERATION__TIME_STAMPED = 4;
 
 	/**
      * The feature id for the '<em><b>Refresh Representations</b></em>' attribute.
@@ -109,7 +118,7 @@ public interface GenconfPackage extends EPackage {
      * @generated
      * @ordered
      */
-    int GENERATION__REFRESH_REPRESENTATIONS = 4;
+    int GENERATION__REFRESH_REPRESENTATIONS = 5;
 
     /**
      * The feature id for the '<em><b>Definitions</b></em>' containment reference list.
@@ -118,7 +127,7 @@ public interface GenconfPackage extends EPackage {
      * @generated
      * @ordered
      */
-	int GENERATION__DEFINITIONS = 5;
+	int GENERATION__DEFINITIONS = 6;
 
 	/**
      * The number of structural features of the '<em>Generation</em>' class.
@@ -127,7 +136,7 @@ public interface GenconfPackage extends EPackage {
      * @generated
      * @ordered
      */
-	int GENERATION_FEATURE_COUNT = 6;
+	int GENERATION_FEATURE_COUNT = 7;
 
 	/**
      * The number of operations of the '<em>Generation</em>' class.
@@ -321,6 +330,17 @@ public interface GenconfPackage extends EPackage {
 	EAttribute getGeneration_ResultFileName();
 
 	/**
+     * Returns the meta object for the attribute '{@link org.obeonetwork.m2doc.genconf.Generation#getRepresentationsFileName <em>Representations File Name</em>}'.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the meta object for the attribute '<em>Representations File Name</em>'.
+     * @see org.obeonetwork.m2doc.genconf.Generation#getRepresentationsFileName()
+     * @see #getGeneration()
+     * @generated
+     */
+    EAttribute getGeneration_RepresentationsFileName();
+
+    /**
      * Returns the meta object for the attribute '{@link org.obeonetwork.m2doc.genconf.Generation#isTimeStamped <em>Time Stamped</em>}'.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -485,6 +505,14 @@ public interface GenconfPackage extends EPackage {
 		EAttribute GENERATION__RESULT_FILE_NAME = eINSTANCE.getGeneration_ResultFileName();
 
 		/**
+         * The meta object literal for the '<em><b>Representations File Name</b></em>' attribute feature.
+         * <!-- begin-user-doc -->
+         * <!-- end-user-doc -->
+         * @generated
+         */
+        EAttribute GENERATION__REPRESENTATIONS_FILE_NAME = eINSTANCE.getGeneration_RepresentationsFileName();
+
+        /**
          * The meta object literal for the '<em><b>Time Stamped</b></em>' attribute feature.
          * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->

--- a/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/Generation.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/Generation.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#getName <em>Name</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#getTemplateFileName <em>Template File Name</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#getResultFileName <em>Result File Name</em>}</li>
+ *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#getRepresentationsFileName <em>Representations File Name</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#isTimeStamped <em>Time Stamped</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#isRefreshRepresentations <em>Refresh Representations</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.Generation#getDefinitions <em>Definitions</em>}</li>
@@ -107,6 +108,32 @@ public interface Generation extends EObject {
 	void setResultFileName(String value);
 
 	/**
+     * Returns the value of the '<em><b>Representations File Name</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <p>
+     * If the meaning of the '<em>Representations File Name</em>' attribute isn't clear,
+     * there really should be more of a description here...
+     * </p>
+     * <!-- end-user-doc -->
+     * @return the value of the '<em>Representations File Name</em>' attribute.
+     * @see #setRepresentationsFileName(String)
+     * @see org.obeonetwork.m2doc.genconf.GenconfPackage#getGeneration_RepresentationsFileName()
+     * @model
+     * @generated
+     */
+    String getRepresentationsFileName();
+
+    /**
+     * Sets the value of the '{@link org.obeonetwork.m2doc.genconf.Generation#getRepresentationsFileName <em>Representations File Name</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @param value the new value of the '<em>Representations File Name</em>' attribute.
+     * @see #getRepresentationsFileName()
+     * @generated
+     */
+    void setRepresentationsFileName(String value);
+
+    /**
      * Returns the value of the '<em><b>Time Stamped</b></em>' attribute.
      * The default value is <code>"true"</code>.
      * <!-- begin-user-doc -->

--- a/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/impl/GenconfPackageImpl.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/impl/GenconfPackageImpl.java
@@ -154,11 +154,20 @@ public class GenconfPackageImpl extends EPackageImpl implements GenconfPackage {
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    public EAttribute getGeneration_RepresentationsFileName() {
+        return (EAttribute)generationEClass.getEStructuralFeatures().get(3);
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
 	public EAttribute getGeneration_TimeStamped() {
-        return (EAttribute)generationEClass.getEStructuralFeatures().get(3);
+        return (EAttribute)generationEClass.getEStructuralFeatures().get(4);
     }
 
 	/**
@@ -167,7 +176,7 @@ public class GenconfPackageImpl extends EPackageImpl implements GenconfPackage {
      * @generated
      */
     public EAttribute getGeneration_RefreshRepresentations() {
-        return (EAttribute)generationEClass.getEStructuralFeatures().get(4);
+        return (EAttribute)generationEClass.getEStructuralFeatures().get(5);
     }
 
     /**
@@ -176,7 +185,7 @@ public class GenconfPackageImpl extends EPackageImpl implements GenconfPackage {
      * @generated
      */
 	public EReference getGeneration_Definitions() {
-        return (EReference)generationEClass.getEStructuralFeatures().get(5);
+        return (EReference)generationEClass.getEStructuralFeatures().get(6);
     }
 
 	/**
@@ -274,6 +283,7 @@ public class GenconfPackageImpl extends EPackageImpl implements GenconfPackage {
         createEAttribute(generationEClass, GENERATION__NAME);
         createEAttribute(generationEClass, GENERATION__TEMPLATE_FILE_NAME);
         createEAttribute(generationEClass, GENERATION__RESULT_FILE_NAME);
+        createEAttribute(generationEClass, GENERATION__REPRESENTATIONS_FILE_NAME);
         createEAttribute(generationEClass, GENERATION__TIME_STAMPED);
         createEAttribute(generationEClass, GENERATION__REFRESH_REPRESENTATIONS);
         createEReference(generationEClass, GENERATION__DEFINITIONS);
@@ -328,6 +338,7 @@ public class GenconfPackageImpl extends EPackageImpl implements GenconfPackage {
         initEAttribute(getGeneration_Name(), ecorePackage.getEString(), "name", null, 0, 1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getGeneration_TemplateFileName(), ecorePackage.getEString(), "templateFileName", null, 0, 1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getGeneration_ResultFileName(), ecorePackage.getEString(), "resultFileName", null, 0, 1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEAttribute(getGeneration_RepresentationsFileName(), ecorePackage.getEString(), "representationsFileName", null, 0, 1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getGeneration_TimeStamped(), ecorePackage.getEBoolean(), "timeStamped", "true", 0, 1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getGeneration_RefreshRepresentations(), theEcorePackage.getEBoolean(), "refreshRepresentations", "false", 0, 1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getGeneration_Definitions(), this.getDefinition(), null, "definitions", null, 0, -1, Generation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/impl/GenerationImpl.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src-gen/org/obeonetwork/m2doc/genconf/impl/GenerationImpl.java
@@ -32,6 +32,7 @@ import org.obeonetwork.m2doc.genconf.Generation;
  *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#getName <em>Name</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#getTemplateFileName <em>Template File Name</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#getResultFileName <em>Result File Name</em>}</li>
+ *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#getRepresentationsFileName <em>Representations File Name</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#isTimeStamped <em>Time Stamped</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#isRefreshRepresentations <em>Refresh Representations</em>}</li>
  *   <li>{@link org.obeonetwork.m2doc.genconf.impl.GenerationImpl#getDefinitions <em>Definitions</em>}</li>
@@ -101,6 +102,26 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
 	protected String resultFileName = RESULT_FILE_NAME_EDEFAULT;
 
 	/**
+     * The default value of the '{@link #getRepresentationsFileName() <em>Representations File Name</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getRepresentationsFileName()
+     * @generated
+     * @ordered
+     */
+    protected static final String REPRESENTATIONS_FILE_NAME_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getRepresentationsFileName() <em>Representations File Name</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getRepresentationsFileName()
+     * @generated
+     * @ordered
+     */
+    protected String representationsFileName = REPRESENTATIONS_FILE_NAME_EDEFAULT;
+
+    /**
      * The default value of the '{@link #isTimeStamped() <em>Time Stamped</em>}' attribute.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -234,6 +255,27 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    public String getRepresentationsFileName() {
+        return representationsFileName;
+    }
+
+    /**
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    public void setRepresentationsFileName(String newRepresentationsFileName) {
+        String oldRepresentationsFileName = representationsFileName;
+        representationsFileName = newRepresentationsFileName;
+        if (eNotificationRequired())
+            eNotify(new ENotificationImpl(this, Notification.SET, GenconfPackage.GENERATION__REPRESENTATIONS_FILE_NAME, oldRepresentationsFileName, representationsFileName));
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
@@ -314,6 +356,8 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
                 return getTemplateFileName();
             case GenconfPackage.GENERATION__RESULT_FILE_NAME:
                 return getResultFileName();
+            case GenconfPackage.GENERATION__REPRESENTATIONS_FILE_NAME:
+                return getRepresentationsFileName();
             case GenconfPackage.GENERATION__TIME_STAMPED:
                 return isTimeStamped();
             case GenconfPackage.GENERATION__REFRESH_REPRESENTATIONS:
@@ -341,6 +385,9 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
                 return;
             case GenconfPackage.GENERATION__RESULT_FILE_NAME:
                 setResultFileName((String)newValue);
+                return;
+            case GenconfPackage.GENERATION__REPRESENTATIONS_FILE_NAME:
+                setRepresentationsFileName((String)newValue);
                 return;
             case GenconfPackage.GENERATION__TIME_STAMPED:
                 setTimeStamped((Boolean)newValue);
@@ -373,6 +420,9 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
             case GenconfPackage.GENERATION__RESULT_FILE_NAME:
                 setResultFileName(RESULT_FILE_NAME_EDEFAULT);
                 return;
+            case GenconfPackage.GENERATION__REPRESENTATIONS_FILE_NAME:
+                setRepresentationsFileName(REPRESENTATIONS_FILE_NAME_EDEFAULT);
+                return;
             case GenconfPackage.GENERATION__TIME_STAMPED:
                 setTimeStamped(TIME_STAMPED_EDEFAULT);
                 return;
@@ -400,6 +450,8 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
                 return TEMPLATE_FILE_NAME_EDEFAULT == null ? templateFileName != null : !TEMPLATE_FILE_NAME_EDEFAULT.equals(templateFileName);
             case GenconfPackage.GENERATION__RESULT_FILE_NAME:
                 return RESULT_FILE_NAME_EDEFAULT == null ? resultFileName != null : !RESULT_FILE_NAME_EDEFAULT.equals(resultFileName);
+            case GenconfPackage.GENERATION__REPRESENTATIONS_FILE_NAME:
+                return REPRESENTATIONS_FILE_NAME_EDEFAULT == null ? representationsFileName != null : !REPRESENTATIONS_FILE_NAME_EDEFAULT.equals(representationsFileName);
             case GenconfPackage.GENERATION__TIME_STAMPED:
                 return timeStamped != TIME_STAMPED_EDEFAULT;
             case GenconfPackage.GENERATION__REFRESH_REPRESENTATIONS:
@@ -426,6 +478,8 @@ public class GenerationImpl extends MinimalEObjectImpl.Container implements Gene
         result.append(templateFileName);
         result.append(", resultFileName: ");
         result.append(resultFileName);
+        result.append(", representationsFileName: ");
+        result.append(representationsFileName);
         result.append(", timeStamped: ");
         result.append(timeStamped);
         result.append(", refreshRepresentations: ");

--- a/plugins/org.obeonetwork.m2doc.genconf/src/org/obeonetwork/m2doc/genconf/provider/IConfigurationProvider.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src/org/obeonetwork/m2doc/genconf/provider/IConfigurationProvider.java
@@ -14,6 +14,7 @@ package org.obeonetwork.m2doc.genconf.provider;
 import java.util.List;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.properties.TemplateCustomProperties;
 import org.obeonetwork.m2doc.template.DocumentTemplate;
@@ -105,4 +106,13 @@ public interface IConfigurationProvider {
      */
     List<URI> postGenerate(Generation generation, URI templateURI, URI generatedURI, DocumentTemplate template);
 
+    /**
+     * Create a new resourceSet which would need specific initialization for loading the models specified in the Generation objects.
+     * 
+     * @param generation
+     *            the generation object containing all the parameters of the document generation.
+     * @return null if no specific resourceset has to be created for this genconf, a ResourceSet instance already configured and ready to
+     *         load models if some specific setup needed to be done.
+     */
+    ResourceSet createResourceSetForModels(Generation generation);
 }

--- a/plugins/org.obeonetwork.m2doc.ide.ui/plugin.xml
+++ b/plugins/org.obeonetwork.m2doc.ide.ui/plugin.xml
@@ -70,10 +70,16 @@
                      <iterate
                            ifEmpty="false"
                            operator="or">
-                         <test
-                               forcePluginActivation="true"
-                               property="org.obeonetwork.m2doc.ide.ui.testGeneration">
-                        </test>
+                         <or>
+                            <test
+                                  forcePluginActivation="true"
+                                  property="org.obeonetwork.m2doc.ide.ui.testGeneration">
+                            </test>
+                            <test
+                                  property="org.eclipse.core.resources.extension"
+                                  value="genconf">
+                            </test>
+                         </or>
                      </iterate>
                   </with>
             </visibleWhen>

--- a/plugins/org.obeonetwork.m2doc.ide.ui/src/org/obeonetwork/m2doc/ide/ui/command/GenerateHandler.java
+++ b/plugins/org.obeonetwork.m2doc.ide.ui/src/org/obeonetwork/m2doc/ide/ui/command/GenerateHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -26,6 +27,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.obeonetwork.m2doc.genconf.GenconfToDocumentGenerator;
 import org.obeonetwork.m2doc.genconf.Generation;
+import org.obeonetwork.m2doc.genconf.util.ConfigurationServices;
 import org.obeonetwork.m2doc.generator.DocumentGenerationException;
 import org.obeonetwork.m2doc.ide.ui.Activator;
 import org.obeonetwork.m2doc.parser.DocumentParserException;
@@ -46,18 +48,20 @@ public class GenerateHandler extends AbstractHandler {
      * the command has been executed, so extract extract the needed information
      * from the application context.
      */
+    @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
         ISelection selection = HandlerUtil.getCurrentSelection(event);
         Shell shell = HandlerUtil.getActiveShell(event);
         if (selection instanceof IStructuredSelection) {
             Object selected = ((IStructuredSelection) selection).getFirstElement();
             Generation generation = null;
+            if (selected instanceof IFile && "genconf".equals(((IFile) selected).getFileExtension())) {
+                URI genconfURI = URI.createPlatformResourceURI(((IFile) selected).getFullPath().toString(), true);
+                generation = ConfigurationServices.getGeneration(genconfURI);
+
+            }
             if (selected instanceof Generation) {
                 generation = (Generation) selected;
-            } else {
-                MessageDialog.openError(shell, "Bad selection",
-                        "Document generation action can only be triggered on Generation object.");
-                return null;
             }
 
             if (generation != null) {
@@ -94,6 +98,10 @@ public class GenerateHandler extends AbstractHandler {
                     MessageDialog.openError(shell, "Generation problem. See the error log for details",
                             "A technical error occured. Please log a bug (see the error log for details)");
                 }
+            } else {
+                MessageDialog.openError(shell, "Bad selection",
+                        "Document generation action can only be triggered on Generation object.");
+                return null;
             }
         } else {
             MessageDialog.openError(shell, "Bad selection",

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
@@ -18,12 +18,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.gmf.runtime.diagram.ui.render.util.CopyToImageUtil;
 import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.business.api.session.SessionManager;
+import org.eclipse.sirius.business.internal.session.SessionTransientAttachment;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.Layer;
+import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.provider.IProvider;
@@ -67,7 +69,8 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
 
     @SuppressWarnings("unchecked")
     @Override
-    public List<String> getRepresentationImagePath(Map<String, Object> parameters) throws ProviderException {
+    public List<String> getRepresentationImagePath(ResourceSet resourceSetForModel, Map<String, Object> parameters)
+            throws ProviderException {
         Generation generation = (Generation) parameters.get(ProviderConstants.CONF_ROOT_OBJECT_KEY);
 
         String rootPath = createTempDirectoryPath();
@@ -88,10 +91,12 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
         } else {
             final CopyToImageUtil imageUtility = new CopyToImageUtil();
             EObject targetRootEObject = (EObject) targetRootObject;
-            Session session = SessionManager.INSTANCE.getSession(targetRootEObject);
-            if (session == null) {
-                throw new ProviderException("Cannot find session associated to the conf model root element.");
+            Option<SessionTransientAttachment> attachement = SessionTransientAttachment
+                    .getSessionTransientAttachement(resourceSetForModel);
+            if (!attachement.some()) {
+                throw new ProviderException("Cannot find session associated to the models.");
             }
+            Session session = attachement.get().getSession();
             checkDiagramDescriptionExist(session, (String) diagramDescriptionName);
             List<DRepresentationDescriptor> representations = SiriusDiagramUtils
                     .getAssociatedRepresentationByDiagramDescriptionAndName(generation, targetRootEObject,

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByTitleProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByTitleProvider.java
@@ -17,11 +17,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.gmf.runtime.diagram.ui.render.util.CopyToImageUtil;
 import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.business.api.session.SessionManager;
+import org.eclipse.sirius.business.internal.session.SessionTransientAttachment;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
+import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.obeonetwork.m2doc.provider.IProvider;
 import org.obeonetwork.m2doc.provider.OptionType;
@@ -63,15 +65,18 @@ public class SiriusDiagramByTitleProvider extends AbstractSiriusDiagramImagesPro
 
     @SuppressWarnings("unchecked")
     @Override
-    public List<String> getRepresentationImagePath(Map<String, Object> parameters) throws ProviderException {
+    public List<String> getRepresentationImagePath(ResourceSet resourceSetForModel, Map<String, Object> parameters)
+            throws ProviderException {
         EObject rootObject = (EObject) parameters.get(ProviderConstants.CONF_ROOT_OBJECT_KEY);
         String rootPath = createTempDirectoryPath();
         List<String> diagramActivatedLayers = (List<String>) parameters
                 .get(ProviderConstants.DIAGRAM_ACTIVATED_LAYERS_KEY);
-        Session session = SessionManager.INSTANCE.getSession(rootObject);
-        if (session == null) {
-            throw new ProviderException("Cannot find session associated to the conf model root element.");
+        Option<SessionTransientAttachment> attachement = SessionTransientAttachment
+                .getSessionTransientAttachement(resourceSetForModel);
+        if (!attachement.some()) {
+            throw new ProviderException("Cannot find session associated to the models.");
         }
+        Session session = attachement.get().getSession();
         Object representationTitle = parameters.get(REPRESENTATION_TITLE_KEY);
         refreshRepresentations = OptionUtil.mustRefreshRepresentation(parameters);
         if (!(representationTitle instanceof String)) {

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/tables/SiriusTableByTitleProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/tables/SiriusTableByTitleProvider.java
@@ -17,9 +17,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.sirius.business.api.dialect.DialectManager;
 import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.business.api.session.SessionManager;
+import org.eclipse.sirius.business.internal.session.SessionTransientAttachment;
+import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.table.metamodel.table.DTable;
 import org.eclipse.sirius.viewpoint.DRepresentation;
 import org.eclipse.sirius.viewpoint.DView;
@@ -42,13 +44,17 @@ public class SiriusTableByTitleProvider extends AbstractSiriusTableProvider {
     private static final String TITLE_OBJECT_KEY = "title";
 
     @Override
-    public List<MTable> getTables(Map<String, Object> parameters) throws ProviderException {
+    public List<MTable> getTables(ResourceSet resourceSetForModels, Map<String, Object> parameters)
+            throws ProviderException {
         EObject rootObject = (EObject) parameters.get(ProviderConstants.CONF_ROOT_OBJECT_KEY);
         boolean refreshTables = OptionUtil.mustRefreshRepresentation(parameters);
-        Session session = SessionManager.INSTANCE.getSession(rootObject);
-        if (session == null) {
-            throw new ProviderException("Cannot find session associated to the conf model root element.");
+        Option<SessionTransientAttachment> attachement = SessionTransientAttachment
+                .getSessionTransientAttachement(resourceSetForModels);
+        if (!attachement.some()) {
+            throw new ProviderException("Cannot find session associated to the models.");
         }
+        Session session = attachement.get().getSession();
+
         Object tableTitle = parameters.get(TITLE_OBJECT_KEY);
         if (!(tableTitle instanceof String)) {
             throw new ProviderException(

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/SessionCleaner.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/session/SessionCleaner.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.genconf.provider.IConfigurationProvider;
 import org.obeonetwork.m2doc.properties.TemplateCustomProperties;
@@ -49,6 +50,12 @@ public class SessionCleaner implements IConfigurationProvider {
             DocumentTemplate template) {
         CleaningJobRegistry.INSTANCE.clean(generation);
         return Collections.emptyList();
+    }
+
+    @Override
+    public ResourceSet createResourceSetForModels(Generation generation) {
+        // unused
+        return null;
     }
 
 }

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/M2DocEvaluator.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/M2DocEvaluator.java
@@ -1011,7 +1011,8 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
             Map<String, Object> parameters;
             try {
                 parameters = setupParametersMap(tableClient, provider);
-                TableClientProcessor tableProcessor = new TableClientProcessor(generatedDocument, provider, parameters);
+                TableClientProcessor tableProcessor = new TableClientProcessor(generatedDocument, provider, parameters,
+                        resourceSetForModels);
                 tableProcessor.generate(tableRun);
             } catch (IllegalArgumentException e) {
                 insertMessage(currentGeneratedParagraph, ValidationMessageLevel.ERROR, e.getMessage());

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/M2DocEvaluator.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/M2DocEvaluator.java
@@ -53,6 +53,7 @@ import org.eclipse.acceleo.query.runtime.impl.QueryEvaluationEngine;
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.URIConverter;
 import org.obeonetwork.m2doc.api.HyperLink;
 import org.obeonetwork.m2doc.parser.TemplateValidationMessage;
@@ -126,7 +127,7 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
     /**
      * variable definition used during generation.
      */
-    private final Stack<Map<String, Object>> variablesStack = new Stack<Map<String, Object>>();
+    private final Stack<Map<String, Object>> variablesStack = new Stack<>();
     /**
      * The generated document.
      */
@@ -180,6 +181,11 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
     private GenerationResult result;
 
     /**
+     * The ResourceSet used to keep the models.
+     */
+    private ResourceSet resourceSetForModels;
+
+    /**
      * Create a new {@link M2DocEvaluator} instance given some definitions
      * and a query environment.
      * 
@@ -189,12 +195,15 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
      *            the {@link UserContentManager}
      * @param queryEnvironment
      *            the query environment used to evaluate queries in the
+     * @param resourceSetForModels
+     *            the resourceset to use for loading the models.
      */
     public M2DocEvaluator(BookmarkManager bookmarkManager, UserContentManager userContentManager,
-            IReadOnlyQueryEnvironment queryEnvironment) {
+            IReadOnlyQueryEnvironment queryEnvironment, ResourceSet resourceSetForModels) {
         this.bookmarkManager = bookmarkManager;
         this.userContentManager = userContentManager;
         this.evaluator = new QueryEvaluationEngine((IQueryEnvironment) queryEnvironment);
+        this.resourceSetForModels = resourceSetForModels;
     }
 
     /**
@@ -947,7 +956,8 @@ public class M2DocEvaluator extends TemplateSwitch<IConstruct> {
             Map<String, Object> parameters;
             try {
                 parameters = setupParametersMapForRepresentation(representation, provider);
-                List<String> imagePaths = ((AbstractDiagramProvider) provider).getRepresentationImagePath(parameters);
+                List<String> imagePaths = ((AbstractDiagramProvider) provider)
+                        .getRepresentationImagePath(resourceSetForModels, parameters);
                 usedProviders.add((AbstractDiagramProvider) provider);
                 for (String imagePathStr : imagePaths) {
                     URI imageURI = URI.createFileURI(imagePathStr);

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/TableClientProcessor.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/generator/TableClientProcessor.java
@@ -26,6 +26,7 @@ import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.obeonetwork.m2doc.parser.ValidationMessageLevel;
 import org.obeonetwork.m2doc.provider.AbstractTableProvider;
 import org.obeonetwork.m2doc.provider.AbstractTableProvider.MCell;
@@ -54,6 +55,8 @@ public final class TableClientProcessor {
     /** The table provider. */
     private final AbstractTableProvider provider;
 
+    private final ResourceSet resourceSetForModels;
+
     /**
      * Constructor.
      * 
@@ -63,11 +66,15 @@ public final class TableClientProcessor {
      *            The table provider, must not be <code>null</code>
      * @param arguments
      *            The map of arguments, cannot be <code>null</code>
+     * @param resourceSetForModels
+     *            the resourceset keeping the model instances.
      */
-    public TableClientProcessor(IBody body, AbstractTableProvider provider, Map<String, Object> arguments) {
+    public TableClientProcessor(IBody body, AbstractTableProvider provider, Map<String, Object> arguments,
+            ResourceSet resourceSetForModels) {
         this.body = checkNotNull(body);
         this.provider = checkNotNull(provider);
         this.parameters = checkNotNull(arguments);
+        this.resourceSetForModels = resourceSetForModels;
     }
 
     /**
@@ -79,7 +86,7 @@ public final class TableClientProcessor {
      *             If the retrieval of the tables from the provider goes wrong.
      */
     public void generate(XWPFRun run) throws ProviderException {
-        List<MTable> tables = provider.getTables(parameters);
+        List<MTable> tables = provider.getTables(resourceSetForModels, parameters);
         boolean first = true;
         for (MTable mtable : tables) {
             XWPFTable table = createTable(run, first, mtable);

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/provider/AbstractDiagramProvider.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/provider/AbstractDiagramProvider.java
@@ -13,6 +13,8 @@ package org.obeonetwork.m2doc.provider;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
 /**
  * {@link IDiagramProvider} instances are used to provide diagram's image file from any modeling tool or technology that porvides graphical
  * representations of models.
@@ -24,6 +26,8 @@ public abstract class AbstractDiagramProvider implements IProvider {
     /**
      * Returns the path to the image file of the diagram.
      * 
+     * @param resourceSetForModels
+     *            the resourceset used for loading the models.
      * @param parameters
      *            a map of all parameter name to the corresponding object the provider can use. Global parameters always available are
      *            {@link ProviderConstants#CONF_ROOT_OBJECT_KEY} which give the EObject of the Genconf model from which the generation has
@@ -32,7 +36,8 @@ public abstract class AbstractDiagramProvider implements IProvider {
      * @throws ProviderException
      *             if a problem occurs during retrieving.
      */
-    public abstract List<String> getRepresentationImagePath(Map<String, Object> parameters) throws ProviderException;
+    public abstract List<String> getRepresentationImagePath(ResourceSet resourceSetForModels,
+            Map<String, Object> parameters) throws ProviderException;
 
     /**
      * Return if the provider is a default one.

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/provider/AbstractTableProvider.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/provider/AbstractTableProvider.java
@@ -14,6 +14,8 @@ package org.obeonetwork.m2doc.provider;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
 /**
  * Abstract super-implementation of all table providers.
  * 
@@ -26,11 +28,14 @@ public abstract class AbstractTableProvider implements IProvider {
      * 
      * @param parameters
      *            Map of arguments
+     * @param resourceSetForModels
+     *            the resourceset used for loading the models.
      * @return The list of table to insert, may be empty but should not be <code>null</code>.
      * @throws ProviderException
      *             If something goes wrong during the computation of the tables.
      */
-    public abstract List<MTable> getTables(Map<String, Object> parameters) throws ProviderException;
+    public abstract List<MTable> getTables(ResourceSet resourceSetForModels, Map<String, Object> parameters)
+            throws ProviderException;
 
     /**
      * Interface that represents a table that can be inserted in a word document.

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/util/M2DocUtils.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/util/M2DocUtils.java
@@ -358,7 +358,7 @@ public final class M2DocUtils {
     private static List<TemplateValidationMessage> parseTemplateInfo(IQueryEnvironment queryEnvironment,
             ClassLoader classLoader, final XWPFDocument document) {
         final TemplateCustomProperties properties = new TemplateCustomProperties(document);
-        final List<TemplateValidationMessage> messages = new ArrayList<TemplateValidationMessage>();
+        final List<TemplateValidationMessage> messages = new ArrayList<>();
         for (String nsURI : properties.getPackagesURIs()) {
             final EPackage ePackage = EPackage.Registry.INSTANCE.getEPackage(nsURI);
             if (ePackage != null) {
@@ -481,6 +481,8 @@ public final class M2DocUtils {
      *            the {@link DocumentTemplate}
      * @param queryEnvironment
      *            the {@link IReadOnlyQueryEnvironment}
+     * @param resourceSetForModels
+     *            the resourceset used to load and process the user models.
      * @param variables
      *            variables
      * @param destination
@@ -490,8 +492,8 @@ public final class M2DocUtils {
      *             if the generation fails
      */
     public static GenerationResult generate(DocumentTemplate documentTemplate,
-            IReadOnlyQueryEnvironment queryEnvironment, Map<String, Object> variables, URI destination)
-            throws DocumentGenerationException {
+            IReadOnlyQueryEnvironment queryEnvironment, ResourceSet resourceSetForModels, Map<String, Object> variables,
+            URI destination) throws DocumentGenerationException {
 
         try (InputStream is = URIConverter.INSTANCE.createInputStream(documentTemplate.eResource().getURI());
                 OPCPackage oPackage = OPCPackage.open(is);
@@ -504,7 +506,8 @@ public final class M2DocUtils {
 
             final BookmarkManager bookmarkManager = new BookmarkManager();
             final UserContentManager userContentManager = new UserContentManager(documentTemplate, destination);
-            final M2DocEvaluator processor = new M2DocEvaluator(bookmarkManager, userContentManager, queryEnvironment);
+            final M2DocEvaluator processor = new M2DocEvaluator(bookmarkManager, userContentManager, queryEnvironment,
+                    resourceSetForModels);
 
             final GenerationResult result = processor.generate(documentTemplate, variables, destinationDocument);
 

--- a/tests/org.obeonetwork.m2doc.sirius.tests/resources/diagram/nominal/nominal.genconf
+++ b/tests/org.obeonetwork.m2doc.sirius.tests/resources/diagram/nominal/nominal.genconf
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<genconf:Generation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:genconf="http://www.obeonetwork.org/m2doc/genconf/1.0" name="nominal" templateFileName="/home/development/git/M2Doc/tests/org.obeonetwork.m2doc.sirius.tests/resources/diagram/nominal/nominal-template.docx"/>
+<genconf:Generation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:genconf="http://www.obeonetwork.org/m2doc/genconf/1.0" name="nominal" representationsFileName="nominal.aird" templateFileName="/home/development/git/M2Doc/tests/org.obeonetwork.m2doc.sirius.tests/resources/diagram/nominal/nominal-template.docx"/>

--- a/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/AbstractM2DocSiriusTest.java
+++ b/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/AbstractM2DocSiriusTest.java
@@ -16,8 +16,10 @@ import java.util.Collection;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
+import org.eclipse.sirius.business.internal.session.SessionTransientAttachment;
 import org.junit.Before;
 
 /**
@@ -42,6 +44,8 @@ public abstract class AbstractM2DocSiriusTest {
         URI uri = URI.createPlatformPluginURI(getAirdPluginPath(), true);
         session = SessionManager.INSTANCE.getSession(uri, new NullProgressMonitor());
         session.open(new NullProgressMonitor());
+        session.getTransactionalEditingDomain().getResourceSet().eAdapters()
+                .add(new SessionTransientAttachment(session));
     }
 
     /**
@@ -65,4 +69,9 @@ public abstract class AbstractM2DocSiriusTest {
         }
         return resource;
     }
+
+    protected ResourceSet getResourceSet() {
+        return session.getTransactionalEditingDomain().getResourceSet();
+    }
+
 }

--- a/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/AbstractTemplatesTestSuite.java
+++ b/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/AbstractTemplatesTestSuite.java
@@ -1,22 +1,9 @@
 package org.obeonetwork.m2doc.sirius.tests;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.URIConverter;
-import org.eclipse.emf.transaction.RecordingCommand;
-import org.eclipse.emf.transaction.TransactionalEditingDomain;
-import org.eclipse.emf.transaction.util.TransactionUtil;
-import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.business.api.session.SessionManager;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.parser.DocumentParserException;
 import org.obeonetwork.m2doc.provider.ProviderRegistry;
 import org.obeonetwork.m2doc.sirius.providers.SiriusDiagramByTitleProvider;
@@ -24,8 +11,6 @@ import org.obeonetwork.m2doc.sirius.providers.SiriusDiagramByTitleProvider;
 public abstract class AbstractTemplatesTestSuite extends org.obeonetwork.m2doc.tests.AbstractTemplatesTestSuite {
 
     private final static SiriusDiagramByTitleProvider PROVIDER = new SiriusDiagramByTitleProvider();
-
-    private Session session = null;
 
     /**
      * Constructor.
@@ -57,89 +42,6 @@ public abstract class AbstractTemplatesTestSuite extends org.obeonetwork.m2doc.t
     public static void afterClass() throws IOException {
         org.obeonetwork.m2doc.tests.AbstractTemplatesTestSuite.afterClass();
         ProviderRegistry.INSTANCE.removeProvider(PROVIDER);
-    }
-
-    @Override
-    protected void setTemplateFileName(final Generation gen, final String templateFileName) {
-        final TransactionalEditingDomain domain = TransactionUtil.getEditingDomain(gen);
-        domain.getCommandStack().execute(new RecordingCommand(domain) {
-            @Override
-            protected void doExecute() {
-                AbstractTemplatesTestSuite.super.setTemplateFileName(gen, templateFileName);
-            }
-        });
-
-    }
-
-    private Session initSession() {
-        final Session res;
-
-        final URI sessionURI = getSessionURI(new File(getTestFolderPath()));
-        if (URIConverter.INSTANCE.exists(sessionURI, Collections.emptyMap())) {
-            final Session s = SessionManager.INSTANCE.getSession(sessionURI, new NullProgressMonitor());
-            s.open(new NullProgressMonitor());
-            res = s;
-        } else {
-            res = null;
-        }
-
-        return res;
-    }
-
-    @Override
-    protected ResourceSet getResourceSet() {
-        final ResourceSet res;
-
-        session = initSession();
-        if (session != null) {
-            res = session.getSessionResource().getResourceSet();
-        } else {
-            res = super.getResourceSet();
-        }
-
-        return res;
-    }
-
-    @Override
-    protected Generation getGeneration(final URI genconfURI, ResourceSet rs) {
-        final Generation res;
-
-        if (session != null) {
-            session.getTransactionalEditingDomain().getCommandStack()
-                    .execute(new RecordingCommand(session.getTransactionalEditingDomain()) {
-
-                        @Override
-                        protected void doExecute() {
-                            session.addSemanticResource(genconfURI, new NullProgressMonitor());
-                        }
-                    });
-            Generation foundGeneration = null;
-            for (Resource r : session.getSemanticResources()) {
-                if (r.getURI().toString().endsWith(".genconf")) {
-                    foundGeneration = (Generation) r.getContents().get(0);
-                }
-            }
-            if (foundGeneration != null) {
-                res = foundGeneration;
-            } else {
-                res = super.getGeneration(genconfURI, rs);
-            }
-        } else {
-            res = super.getGeneration(genconfURI, rs);
-        }
-
-        return res;
-    }
-
-    /**
-     * Gets the session {@link URI} from the test folder path.
-     * 
-     * @param testFolder
-     *            the test folder path
-     * @return the session {@link URI} from the test folder path
-     */
-    protected URI getSessionURI(File testFolder) {
-        return URI.createURI(testFolder.toURI().toString() + testFolder.getName() + ".aird");
     }
 
 }

--- a/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/SiriusDiagramByDiagramDescriptionNameProviderTest.java
+++ b/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/SiriusDiagramByDiagramDescriptionNameProviderTest.java
@@ -78,7 +78,8 @@ public class SiriusDiagramByDiagramDescriptionNameProviderTest extends AbstractM
         options.put("object", generation);
         options.put("layers", Collections.EMPTY_LIST);
         // CHECKSTYLE:ON
-        List<String> representationImagePaths = siriusDiagramProvider.getRepresentationImagePath(options);
+        List<String> representationImagePaths = siriusDiagramProvider.getRepresentationImagePath(getResourceSet(),
+                options);
         assertEquals(2, representationImagePaths.size());
         File imageFile = new File(representationImagePaths.get(0));
         assertTrue(imageFile.exists());
@@ -103,7 +104,7 @@ public class SiriusDiagramByDiagramDescriptionNameProviderTest extends AbstractM
         // CHECKSTYLE:ON
         options.put("descriptionId", "GenerationDiagram");
         try {
-            siriusDiagramProvider.getRepresentationImagePath(options);
+            siriusDiagramProvider.getRepresentationImagePath(getResourceSet(), options);
             throw new AssertionFailedError("An exception should have been thrown");
         } catch (ProviderException e) {
             assertEquals(
@@ -130,7 +131,7 @@ public class SiriusDiagramByDiagramDescriptionNameProviderTest extends AbstractM
         options.put("descriptionId", "wrongDiagramDescription");
         options.put("object", generation);
         try {
-            siriusDiagramProvider.getRepresentationImagePath(options);
+            siriusDiagramProvider.getRepresentationImagePath(getResourceSet(), options);
             throw new AssertionFailedError("An exception should have been thrown");
         } catch (ProviderException e) {
             assertEquals("The provided diagram description 'wrongDiagramDescription' does not exist in the loaded aird",
@@ -154,7 +155,7 @@ public class SiriusDiagramByDiagramDescriptionNameProviderTest extends AbstractM
         // CHECKSTYLE:ON
         options.put("rootObject", generation);
         try {
-            siriusDiagramProvider.getRepresentationImagePath(options);
+            siriusDiagramProvider.getRepresentationImagePath(getResourceSet(), options);
             throw new AssertionFailedError("An exception should have been thrown");
         } catch (ProviderException e) {
             assertEquals(
@@ -182,7 +183,8 @@ public class SiriusDiagramByDiagramDescriptionNameProviderTest extends AbstractM
         // CHECKSTYLE:ON
         options.put("descriptionId", "TestGenerationDiagram");
         options.put("object", generation.getDefinitions().get(0));
-        List<String> representationImagePaths = siriusDiagramProvider.getRepresentationImagePath(options);
+        List<String> representationImagePaths = siriusDiagramProvider.getRepresentationImagePath(getResourceSet(),
+                options);
         assertEquals(0, representationImagePaths.size());
     }
 

--- a/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/SiriusDiagramByTitleProviderTest.java
+++ b/tests/org.obeonetwork.m2doc.sirius.tests/src/org/obeonetwork/m2doc/sirius/tests/SiriusDiagramByTitleProviderTest.java
@@ -89,7 +89,8 @@ public class SiriusDiagramByTitleProviderTest extends AbstractM2DocSiriusTest {
         // CHECKSTYLE:ON
         options.put("title", "new GenerationDiagram");
         options.put("layers", Collections.EMPTY_LIST);
-        List<String> representationImagePaths = siriusDiagramByTitleProvider.getRepresentationImagePath(options);
+        List<String> representationImagePaths = siriusDiagramByTitleProvider
+                .getRepresentationImagePath(getResourceSet(), options);
         assertEquals(1, representationImagePaths.size());
         File imageFile = new File(representationImagePaths.get(0));
         assertTrue(imageFile.exists());
@@ -112,7 +113,7 @@ public class SiriusDiagramByTitleProviderTest extends AbstractM2DocSiriusTest {
         // CHECKSTYLE:ON
         options.put("title", "wrongReference");
         try {
-            siriusDiagramByTitleProvider.getRepresentationImagePath(options);
+            siriusDiagramByTitleProvider.getRepresentationImagePath(getResourceSet(), options);
             throw new AssertionFailedError("An exception should have been thrown");
         } catch (ProviderException e) {
             assertEquals("Representation with title 'wrongReference' not found", e.getMessage());
@@ -135,7 +136,7 @@ public class SiriusDiagramByTitleProviderTest extends AbstractM2DocSiriusTest {
         // CHECKSTYLE:ON
         options.put("title", 0);
         try {
-            siriusDiagramByTitleProvider.getRepresentationImagePath(options);
+            siriusDiagramByTitleProvider.getRepresentationImagePath(getResourceSet(), options);
             throw new AssertionFailedError("An exception should have been thrown");
         } catch (ProviderException e) {
             assertEquals(
@@ -159,7 +160,7 @@ public class SiriusDiagramByTitleProviderTest extends AbstractM2DocSiriusTest {
         options.put(ProviderConstants.IMAGE_WIDTH_KEY, 500);
         // CHECKSTYLE:ON
         try {
-            siriusDiagramByTitleProvider.getRepresentationImagePath(options);
+            siriusDiagramByTitleProvider.getRepresentationImagePath(getResourceSet(), options);
             throw new AssertionFailedError("An exception should have been thrown");
         } catch (ProviderException e) {
             assertEquals(

--- a/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/generator/TableClientProcessorSeveralTablesTests.java
+++ b/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/generator/TableClientProcessorSeveralTablesTests.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.poi.xwpf.usermodel.XWPFTable;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.junit.Test;
 import org.obeonetwork.m2doc.generator.TableClientProcessor;
 import org.obeonetwork.m2doc.provider.AbstractTableProvider.MTable;
@@ -35,8 +36,8 @@ public class TableClientProcessorSeveralTablesTests extends TableClientProcessor
     @Override
     @Test
     public void testWithoutAnyParameter() throws ProviderException {
-        Map<String, Object> arguments = new HashMap<String, Object>();
-        processor = new TableClientProcessor(doc, provider, arguments);
+        Map<String, Object> arguments = new HashMap<>();
+        processor = new TableClientProcessor(doc, provider, arguments, new ResourceSetImpl());
         processor.generate(run);
 
         checkParagraph(paragraph, "Test Table");
@@ -51,7 +52,7 @@ public class TableClientProcessorSeveralTablesTests extends TableClientProcessor
     public void testWithParamHideTitleFalse() throws ProviderException {
         Map<String, Object> arguments = new HashMap<String, Object>();
         arguments.put("hideTitle", "false");
-        processor = new TableClientProcessor(doc, provider, arguments);
+        processor = new TableClientProcessor(doc, provider, arguments, new ResourceSetImpl());
         processor.generate(run);
 
         checkParagraph(paragraph, "Test Table");
@@ -66,7 +67,7 @@ public class TableClientProcessorSeveralTablesTests extends TableClientProcessor
     public void testWithParamHideTitleTrue() throws ProviderException {
         Map<String, Object> arguments = new HashMap<String, Object>();
         arguments.put("hideTitle", "true");
-        processor = new TableClientProcessor(doc, provider, arguments);
+        processor = new TableClientProcessor(doc, provider, arguments, new ResourceSetImpl());
         processor.generate(run);
 
         assertEquals("", paragraph.getText());

--- a/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/generator/TableClientProcessorTests.java
+++ b/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/generator/TableClientProcessorTests.java
@@ -22,6 +22,8 @@ import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.obeonetwork.m2doc.generator.TableClientProcessor;
@@ -55,8 +57,8 @@ public class TableClientProcessorTests {
 
     @Test
     public void testWithoutAnyParameter() throws ProviderException {
-        Map<String, Object> arguments = new HashMap<String, Object>();
-        processor = new TableClientProcessor(doc, provider, arguments);
+        Map<String, Object> arguments = new HashMap<>();
+        processor = new TableClientProcessor(doc, provider, arguments, new ResourceSetImpl());
         processor.generate(run);
 
         checkParagraph(paragraph, "Test Table");
@@ -68,9 +70,9 @@ public class TableClientProcessorTests {
 
     @Test
     public void testWithParamHideTitleFalse() throws ProviderException {
-        Map<String, Object> arguments = new HashMap<String, Object>();
+        Map<String, Object> arguments = new HashMap<>();
         arguments.put("hideTitle", "false");
-        processor = new TableClientProcessor(doc, provider, arguments);
+        processor = new TableClientProcessor(doc, provider, arguments, new ResourceSetImpl());
         processor.generate(run);
 
         checkParagraph(paragraph, "Test Table");
@@ -82,9 +84,9 @@ public class TableClientProcessorTests {
 
     @Test
     public void testWithParamHideTitleTrue() throws ProviderException {
-        Map<String, Object> arguments = new HashMap<String, Object>();
+        Map<String, Object> arguments = new HashMap<>();
         arguments.put("hideTitle", "true");
-        processor = new TableClientProcessor(doc, provider, arguments);
+        processor = new TableClientProcessor(doc, provider, arguments, new ResourceSetImpl());
         processor.generate(run);
 
         assertEquals("", paragraph.getText());
@@ -130,7 +132,7 @@ public class TableClientProcessorTests {
             }
 
             @Override
-            public List<MTable> getTables(Map<String, Object> parameters) throws ProviderException {
+            public List<MTable> getTables(ResourceSet set, Map<String, Object> parameters) throws ProviderException {
                 return getTestTables();
             }
 
@@ -147,7 +149,7 @@ public class TableClientProcessorTests {
      * @return The list of tables to use in this test class. Can be overridden.
      */
     protected List<MTable> getTestTables() {
-        List<MTable> result = new ArrayList<MTable>();
+        List<MTable> result = new ArrayList<>();
         result.add(getTestTable());
         return result;
     }
@@ -228,8 +230,8 @@ public class TableClientProcessorTests {
     }
 
     public static class TestTable extends TestLabeledElement implements MTable {
-        protected final List<TestColumn> columns = new ArrayList<TestColumn>();
-        protected final List<TestRow> rows = new ArrayList<TestRow>();
+        protected final List<TestColumn> columns = new ArrayList<>();
+        protected final List<TestRow> rows = new ArrayList<>();
 
         public TestTable(String label) {
             super(label);
@@ -249,7 +251,7 @@ public class TableClientProcessorTests {
 
     public static class TestRow extends TestStyledElement implements MRow {
 
-        protected final List<TestCell> cells = new ArrayList<TestCell>();
+        protected final List<TestCell> cells = new ArrayList<>();
 
         public TestRow(String label) {
             super(label);

--- a/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/provider/ProviderRegistryTests.java
+++ b/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/provider/ProviderRegistryTests.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.obeonetwork.m2doc.provider.AbstractDiagramProvider;
@@ -66,7 +67,8 @@ public class ProviderRegistryTests {
          * @see org.obeonetwork.m2doc.provider.DiagramProvider#getRepresentationImagePath(java.util.Map)
          */
         @Override
-        public List<String> getRepresentationImagePath(Map<String, Object> parameters) throws ProviderException {
+        public List<String> getRepresentationImagePath(ResourceSet resourceSetForModels, Map<String, Object> parameters)
+                throws ProviderException {
             return null;
         }
 

--- a/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/provider/TestDiagramProvider.java
+++ b/tests/org.obeonetwork.m2doc.tests/src/org/obeonetwork/m2doc/tests/provider/TestDiagramProvider.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.obeonetwork.m2doc.provider.AbstractDiagramProvider;
 import org.obeonetwork.m2doc.provider.OptionType;
 import org.obeonetwork.m2doc.provider.ProviderException;
@@ -72,7 +73,8 @@ public class TestDiagramProvider extends AbstractDiagramProvider {
      * @see org.obeonetwork.m2doc.provider.DiagramProvider#getRepresentationImagePath(java.util.Map)
      */
     @Override
-    public List<String> getRepresentationImagePath(Map<String, Object> parameters) throws ProviderException {
+    public List<String> getRepresentationImagePath(ResourceSet resourceSetForModels, Map<String, Object> parameters)
+            throws ProviderException {
         String resultKind = (String) parameters.get(RESULT_KIND_KEY);
         String aqlExpression = (String) parameters.get(AQL_EXPRESSION_OPTION_KEY);
         List<String> imagesPaths = new ArrayList<>();


### PR DESCRIPTION
This set of commits adapt the runtime so that:
- different resourceset are used for reading the models and for managing the genconf instances
- an extension point can be reused to setup a resourceset in a specific way based on some genconf parameters
- a new parameter in the genconf is added to specify the path to a representation file
- the action to launch the generation is now also available directly on the genconf file (this required the previous steps) so that one could launch a generation without having to open the genconf.