### PR TITLE
InfinitLoopSafeService removal followup: use the Sirius dedicated API

### DIFF
--- a/plugins/org.obeonetwork.m2doc.sirius/META-INF/MANIFEST.MF
+++ b/plugins/org.obeonetwork.m2doc.sirius/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.sirius.table;bundle-version="[4.1.0,5.0.0)",
  org.obeonetwork.m2doc;bundle-version="[0.10.0,0.11.0)",
  com.google.guava;bundle-version="[15.0.0,16.0.0)",
- org.obeonetwork.m2doc.genconf;bundle-version="[0.10.0,0.11.0)"
+ org.obeonetwork.m2doc.genconf;bundle-version="[0.10.0,0.11.0)",
+ org.eclipse.sirius.common;bundle-version="4.1.4"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: org.obeonetwork.m2doc.sirius.commands,

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByDiagramDescriptionNameProvider.java
@@ -18,12 +18,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.gmf.runtime.diagram.ui.render.util.CopyToImageUtil;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.Layer;
+import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.provider.IProvider;
@@ -86,7 +86,6 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
                     "Image cannot be computed because no root EObject has been provided to the provider \""
                         + this.getClass().getName() + "\"");
         } else {
-            final CopyToImageUtil imageUtility = new CopyToImageUtil();
             EObject targetRootEObject = (EObject) targetRootObject;
             Session session = SessionManager.INSTANCE.getSession(targetRootEObject);
             if (session == null) {
@@ -100,11 +99,11 @@ public class SiriusDiagramByDiagramDescriptionNameProvider extends AbstractSiriu
             final List<String> result;
             if (!representations.isEmpty() && representations.get(0).getDescription() instanceof DiagramDescription) {
                 DDiagram resolvedDiagram = (DDiagram) representations.get(0).getRepresentation();
-                result = SiriusDiagramUtils.generateAndReturnDiagramImages(rootPath, session, imageUtility,
-                        createIfAbsent, representations, getLayers(resolvedDiagram, diagramActivatedLayers));
+                result = SiriusDiagramUtils.generateAndReturnDiagramImages(rootPath, session, createIfAbsent,
+                        representations, getLayers(resolvedDiagram, diagramActivatedLayers));
             } else {
-                result = SiriusDiagramUtils.generateAndReturnDiagramImages(rootPath, session, imageUtility,
-                        createIfAbsent, representations, Lists.<Layer> newArrayList());
+                result = SiriusDiagramUtils.generateAndReturnDiagramImages(rootPath, session, createIfAbsent,
+                        representations, Lists.<Layer> newArrayList());
             }
 
             return result;

--- a/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByTitleProvider.java
+++ b/plugins/org.obeonetwork.m2doc.sirius/src/org/obeonetwork/m2doc/sirius/providers/SiriusDiagramByTitleProvider.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.gmf.runtime.diagram.ui.render.util.CopyToImageUtil;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.diagram.DDiagram;
@@ -85,10 +84,8 @@ public class SiriusDiagramByTitleProvider extends AbstractSiriusDiagramImagesPro
                 DDiagram resolvedDiagram = (DDiagram) representation.getRepresentation();
                 List<DRepresentationDescriptor> representations = new ArrayList<>(1);
                 representations.add(representation);
-                final CopyToImageUtil imageUtility = new CopyToImageUtil();
                 List<String> resultList = SiriusDiagramUtils.generateAndReturnDiagramImages(rootPath, session,
-                        imageUtility, refreshRepresentations, representations,
-                        getLayers(resolvedDiagram, diagramActivatedLayers));
+                        refreshRepresentations, representations, getLayers(resolvedDiagram, diagramActivatedLayers));
 
                 return resultList;
             } else {


### PR DESCRIPTION
There is an official API in Sirius for exporting diagrams to images,
instead of copy/pasting things better use it. 
This commit also make sure the export is going to be done in the UI
Thread as this is a requirement for it to work.