### PR TITLE
Fix template validation not working

### DIFF
--- a/plugins/org.obeonetwork.m2doc.genconf/src/org/obeonetwork/m2doc/genconf/GenconfToDocumentGenerator.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src/org/obeonetwork/m2doc/genconf/GenconfToDocumentGenerator.java
@@ -430,20 +430,20 @@ public class GenconfToDocumentGenerator {
         URI generationURI = generation.eResource().getURI();
 
         // get template and result file
-        URI templateFile = generationURI.trimSegments(1).appendSegment(generation.getTemplateFileName());
-        if (!URIConverter.INSTANCE.exists(templateFile, Collections.EMPTY_MAP)) {
-            throw new DocumentGenerationException("The template file doest not exist " + templateFilePath);
+        URI templateURI = URI.createFileURI(generation.getTemplateFileName()).resolve(generationURI);
+        if (!URIConverter.INSTANCE.exists(templateURI, Collections.EMPTY_MAP)) {
+            throw new DocumentGenerationException("The template file does not exist " + templateFilePath);
         }
         // get acceleo environment
         IQueryEnvironment queryEnvironment = configurationServices.initAcceleoEnvironment(generation);
 
         // parse template
-        try (DocumentTemplate template = M2DocUtils.parse(templateFile, queryEnvironment,
+        try (DocumentTemplate template = M2DocUtils.parse(templateURI, queryEnvironment,
                 this.getClass().getClassLoader())) {
 
             // validate template
             if (template != null) {
-                res = validate(templateFile, template, generation);
+                res = validate(templateURI, template, generation);
             } else {
                 res = true;
             }

--- a/plugins/org.obeonetwork.m2doc.genconf/src/org/obeonetwork/m2doc/genconf/GenconfToDocumentGenerator.java
+++ b/plugins/org.obeonetwork.m2doc.genconf/src/org/obeonetwork/m2doc/genconf/GenconfToDocumentGenerator.java
@@ -199,7 +199,7 @@ public class GenconfToDocumentGenerator {
 
             // validate template
             monitor.beginTask("Validating template.", 1);
-            boolean inError = validate(generatedFile, template, generation);
+            boolean inError = validate(generatedFile, template, queryEnvironment, generation);
             monitor.done();
 
             // add providers variables
@@ -443,7 +443,7 @@ public class GenconfToDocumentGenerator {
 
             // validate template
             if (template != null) {
-                res = validate(templateURI, template, generation);
+                res = validate(templateURI, template, queryEnvironment, generation);
             } else {
                 res = true;
             }
@@ -459,6 +459,8 @@ public class GenconfToDocumentGenerator {
      *            File
      * @param documentTemplate
      *            DocumentTemplate
+     * @param queryEnvironment
+     *            the {@link IQueryEnvironment}
      * @param generation
      *            Generation
      * @return if template contains errors/warnings/info
@@ -467,10 +469,8 @@ public class GenconfToDocumentGenerator {
      * @throws IOException
      *             IOException
      */
-    public boolean validate(URI templateFile, DocumentTemplate documentTemplate, Generation generation)
-            throws DocumentGenerationException, IOException {
-        final IQueryEnvironment queryEnvironment = configurationServices.initAcceleoEnvironment(generation);
-
+    public boolean validate(URI templateFile, DocumentTemplate documentTemplate, IQueryEnvironment queryEnvironment,
+            Generation generation) throws DocumentGenerationException, IOException {
         return validate(templateFile, documentTemplate, generation, queryEnvironment);
     }
 


### PR DESCRIPTION
This PR fixes the following issues:
* The validation was not using the correct URI for the template.
* The validation was, in some cases, not using the right query environment.

Validating a template should now work as intended.