### PR TITLE
Missing 'plugin.properties' file from the build of plugin m2doc.ide

### DIFF
--- a/plugins/org.obeonetwork.m2doc.ide/build.properties
+++ b/plugins/org.obeonetwork.m2doc.ide/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               schema/
+               schema/,\
+               plugin.properties


### PR DESCRIPTION
Change-Id: I1b1447d381178d20e50a234fc1ba9df1fe0de242
Signed-off-by: Florent Latombe <florent.latombe@obeo.fr>