### PR TITLE
#236: Move 'Resource createConfigurationModel(URI)' to GenconfUtils.

### DIFF
--- a/plugins/org.obeonetwork.m2doc.genconf.editor/src/org/obeonetwork/m2doc/genconf/editor/command/InitializeConfigurationsHandler.java
+++ b/plugins/org.obeonetwork.m2doc.genconf.editor/src/org/obeonetwork/m2doc/genconf/editor/command/InitializeConfigurationsHandler.java
@@ -13,9 +13,6 @@ package org.obeonetwork.m2doc.genconf.editor.command;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -24,23 +21,13 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.URIConverter;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.obeonetwork.m2doc.POIServices;
-import org.obeonetwork.m2doc.genconf.Definition;
-import org.obeonetwork.m2doc.genconf.GenconfFactory;
-import org.obeonetwork.m2doc.genconf.GenconfPlugin;
 import org.obeonetwork.m2doc.genconf.GenconfUtils;
-import org.obeonetwork.m2doc.genconf.Generation;
 import org.obeonetwork.m2doc.genconf.presentation.M2docconfEditorPlugin;
-import org.obeonetwork.m2doc.properties.TemplateCustomProperties;
 
 /**
  * Initialize configurations for documention generation.
@@ -66,7 +53,7 @@ public class InitializeConfigurationsHandler extends AbstractHandler {
             Object selected = ((IStructuredSelection) selection).getFirstElement();
             if (selected instanceof IFile) {
                 try {
-                    Resource configurationModel = createConfigurationModel(
+                    Resource configurationModel = GenconfUtils.createConfigurationModel(
                             URI.createPlatformResourceURI(((IFile) selected).getFullPath().toString(), true));
                     MessageDialog.openInformation(shell, "M2Doc generation", "The configuration file '"
                         + configurationModel.getURI().toPlatformString(true) + "' is created.");
@@ -91,117 +78,6 @@ public class InitializeConfigurationsHandler extends AbstractHandler {
         }
         return null;
 
-    }
-
-    /**
-     * Create genconf model from templateInfo information.
-     * 
-     * @param templateURI
-     *            the template {@link URI}
-     * @return configuration model
-     * @throws InvalidFormatException
-     *             InvalidFormatException
-     * @throws IOException
-     *             IOException
-     */
-    protected Resource createConfigurationModel(URI templateURI) throws IOException {
-        Resource resource = null;
-        TemplateCustomProperties templateProperties = POIServices.getInstance()
-                .getTemplateCustomProperties(URIConverter.INSTANCE, templateURI);
-
-        // create genconf model
-        if (templateProperties != null) {
-            resource = createConfigurationModel(templateProperties, templateURI);
-        }
-        return resource;
-    }
-
-    /**
-     * Create resource.
-     * 
-     * @param templateFile
-     *            IFile
-     * @param genConfURI
-     *            URI
-     * @return new resource.
-     */
-    protected Resource createResource(URI templateFile, URI genConfURI) {
-        // Create a resource set
-        ResourceSet resourceSet = new ResourceSetImpl();
-        // Create a resource for this file.
-        Resource resource = resourceSet.createResource(genConfURI);
-        return resource;
-    }
-
-    /**
-     * Create genconf model from templateInfo information.
-     * 
-     * @param templateProperties
-     *            TemplateInfo
-     * @param templateURI
-     *            File
-     * @return configuration model
-     */
-    protected Resource createConfigurationModel(TemplateCustomProperties templateProperties, final URI templateURI) {
-        // create genconf resource.
-        URI genConfURI = templateURI.trimFileExtension().appendFileExtension(GenconfUtils.GENCONF_EXTENSION_FILE);
-        Resource resource = createResource(templateURI, genConfURI);
-
-        // create initial model content.
-        final Generation generation = createInitialModel(genConfURI.trimFileExtension().lastSegment(),
-                templateURI.deresolve(genConfURI).toString());
-        // add docx properties
-        final List<Definition> definitions = GenconfUtils.getNewDefinitions(generation, templateProperties);
-        generation.getDefinitions().addAll(definitions);
-        if (generation != null) {
-            resource.getContents().add(generation);
-        }
-        // Save the contents of the resource to the file system.
-        try {
-            saveResource(resource);
-        } catch (IOException e) {
-            GenconfPlugin.INSTANCE
-                    .log(new Status(Status.ERROR, GenconfPlugin.PLUGIN_ID, Status.ERROR, e.getMessage(), e));
-        }
-
-        // Save the contents of the resource to the file system.
-        try {
-            saveResource(resource);
-        } catch (IOException e) {
-            GenconfPlugin.INSTANCE
-                    .log(new Status(Status.ERROR, GenconfPlugin.PLUGIN_ID, Status.ERROR, e.getMessage(), e));
-        }
-        return resource;
-    }
-
-    /**
-     * Create generation eObject.
-     * 
-     * @param name
-     *            the name
-     * @param templateFileName
-     *            the template file name
-     * @return the created {@link Generation}
-     */
-    protected Generation createInitialModel(String name, String templateFileName) {
-        Generation generation = GenconfFactory.eINSTANCE.createGeneration();
-        generation.setName(name);
-        generation.setTemplateFileName(templateFileName);
-        return generation;
-    }
-
-    /**
-     * Save the contents of the resource to the file system.
-     * 
-     * @param resource
-     *            Resource
-     * @throws IOException
-     *             if the resource can't be serialized
-     */
-    protected void saveResource(Resource resource) throws IOException {
-        Map<Object, Object> options = new HashMap<>();
-        options.put(XMLResource.OPTION_ENCODING, "UTF-8");
-        resource.save(options);
     }
 
 }

--- a/plugins/org.obeonetwork.m2doc.genconf/META-INF/MANIFEST.MF
+++ b/plugins/org.obeonetwork.m2doc.genconf/META-INF/MANIFEST.MF
@@ -17,5 +17,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.acceleo.query;bundle-version="[5.0.0,7.0.0)",
  org.obeonetwork.m2doc;bundle-version="[0.12.0,0.13.0)",
  org.eclipse.emf.ecore.xmi,
- org.obeonetwork.m2doc.ide
+ org.obeonetwork.m2doc.ide,
+ org.apache.poi
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/POIServices.java
+++ b/plugins/org.obeonetwork.m2doc/src/org/obeonetwork/m2doc/POIServices.java
@@ -128,8 +128,6 @@ public final class POIServices {
      * @param templateURI
      *            the template {@link URI}
      * @return TemplateInfo
-     * @throws InvalidFormatException
-     *             InvalidFormatException
      * @throws IOException
      *             IOException
      */


### PR DESCRIPTION
I also updated the Javadoc of the method as it had a mention of an exception that seems to be no longer thrown.

Change-Id: I17293205f937b837b57e94b6cf4399ba5eb6fb99
Signed-off-by: Florent Latombe <florent.latombe@obeo.fr>