### PR TITLE
Make sure we use UTF-8 when giving Batik its input SVG files

### DIFF
--- a/plugins/org.obeonetwork.m2doc.html/src/org/obeonetwork/m2doc/html/services/M2DocHTMLParser.java
+++ b/plugins/org.obeonetwork.m2doc.html/src/org/obeonetwork/m2doc/html/services/M2DocHTMLParser.java
@@ -766,7 +766,8 @@ public class M2DocHTMLParser extends Parser {
                     insertTable(parent, context, tHeader, tBody);
                 }
             } else if (SVG_TAG.equals(node.nodeName())) {
-                final MImageImpl mImage = new MImageImpl(svgs.get(svgIndex++).getBytes(), PictureType.SVG);
+                final MImageImpl mImage = new MImageImpl(svgs.get(svgIndex++).getBytes(StandardCharsets.UTF_8),
+                        PictureType.SVG);
                 final MList parentContents = (MList) parent.getContents();
                 parentContents.add(mImage);
             } else {


### PR DESCRIPTION
Batik seems to assume the input bytes are in UTF-8 as it fails to read some special characters from CP1252-encoded SVG images